### PR TITLE
Improve browsing history recording with debouncing and deduplication

### DIFF
--- a/src/main/browser/browsing-history-manager.ts
+++ b/src/main/browser/browsing-history-manager.ts
@@ -40,6 +40,31 @@ export abstract class BrowsingHistoryManager {
     return newlyCreatedRecord;
   }
 
+  public static async updateRecordTitle(appWindowId: string, recordId: string, title: string): Promise<void>{
+    const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
+    const stmt = db.prepare("UPDATE browsingHistory SET title = ? WHERE id = ?;");
+    await stmt.run(title, recordId);
+  }
+
+  public static async updateRecordFavicon(appWindowId: string, recordId: string, faviconUrl: string): Promise<void>{
+    const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
+    const stmt = db.prepare("UPDATE browsingHistory SET faviconUrl = ? WHERE id = ?;");
+    await stmt.run(faviconUrl, recordId);
+  }
+
+  public static async findLastRecordByUrl(appWindowId: string, url: string): Promise<BrowsingHistoryRecord | null>{
+    const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
+    const stmt = db.prepare("SELECT * FROM browsingHistory WHERE url = ? ORDER BY createdDate DESC LIMIT 1;");
+    const record = stmt.get(url) as BrowsingHistoryRecord | undefined;
+    return record || null;
+  }
+
+  public static async updateRecordTimestamp(appWindowId: string, recordId: string): Promise<void>{
+    const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
+    const stmt = db.prepare("UPDATE browsingHistory SET createdDate = ? WHERE id = ?;");
+    await stmt.run(new Date().toISOString(), recordId);
+  }
+
   public static async removeRecord(appWindowId: string, recordId: string): Promise<boolean>{
     const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
     const stmt = db.prepare("DELETE FROM browsingHistory WHERE id = ?;");


### PR DESCRIPTION
## Summary
This PR enhances the browsing history feature by implementing debounced navigation handling and deduplication logic to prevent duplicate history entries and improve performance during rapid navigation events.

## Key Changes

- **Added debouncing for navigation events**: Navigation completion is now debounced with a 500ms delay to avoid recording multiple history entries for rapid navigation events (both hard and soft navigation).

- **Implemented history deduplication**: When a URL is navigated to again, the system now updates the timestamp of the existing history record instead of creating a duplicate entry.

- **Improved history record tracking**: Added `lastHistoryRecordId` field to track the current history record, enabling updates to title and favicon after the initial record creation.

- **Enhanced title and favicon updates**: The PAGE_TITLE_UPDATED and PAGE_FAVICON_UPDATED event handlers now update the corresponding history record with the actual page title and favicon URL once they become available.

- **Refactored navigation handling**: Split `handleNavigationCompletion()` into three focused methods:
  - `debouncedHandleNavigationCompletion()`: Handles debouncing and immediate UI updates
  - `sendTabUrlUpdate()`: Sends URL and bookmark status to the renderer
  - `recordHistory()`: Handles history recording with deduplication logic

- **Added BrowsingHistoryManager methods**:
  - `updateRecordTitle()`: Updates the title of an existing history record
  - `updateRecordFavicon()`: Updates the favicon URL of an existing history record
  - `findLastRecordByUrl()`: Finds the most recent history record for a given URL
  - `updateRecordTimestamp()`: Updates the timestamp of an existing record

## Notable Implementation Details

- The debounce timer is cleared and reset on each navigation event, ensuring only the final navigation in a burst is recorded.
- URL and bookmark status updates are sent immediately to the renderer for responsive UI, while history recording is debounced.
- Duplicate prevention checks the most recent history entry by URL before creating a new record.
- Title and favicon updates are now properly associated with their corresponding history records via the tracked `lastHistoryRecordId`.

https://claude.ai/code/session_01Ss7Fr8kANhPjoBdxwodyNY