### PR TITLE
Fix Windows installer creation by rebuilding electron-winstaller

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # Rebuild electron-winstaller to download Squirrel vendor binaries
+      # (skipped by --ignore-scripts but required for Windows installer creation)
+      - name: Setup electron-winstaller
+        if: matrix.platform == 'win'
+        shell: bash
+        run: npm rebuild electron-winstaller
+
       # Rebuild DMG native modules (macOS only)
       - name: Rebuild DMG native modules (macOS only)
         if: matrix.platform == 'mac'


### PR DESCRIPTION
## Summary
Added a build step to rebuild the `electron-winstaller` package on Windows, which is necessary to download Squirrel vendor binaries required for Windows installer creation.

## Key Changes
- Added a new build step that runs `npm rebuild electron-winstaller` on Windows platforms
- This step executes after `npm ci --ignore-scripts` to ensure the necessary native binaries are available
- The rebuild is skipped on non-Windows platforms to avoid unnecessary build overhead

## Implementation Details
The `npm ci --ignore-scripts` command skips all post-install scripts, which prevents `electron-winstaller` from downloading its required Squirrel vendor binaries. By explicitly rebuilding this package after the initial dependency installation, we ensure these binaries are available when the Windows installer is created later in the build process.

https://claude.ai/code/session_01659NKjtA4RWgo39LSK2VrL