### PR TITLE
Update macOS build runner from macos-13 to macos-15

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           # macOS builds
-          - os: macos-13        # Intel runner for x64
+          - os: macos-15        # Cross-compile for x64
             platform: mac
             arch: x64
             artifact_name: macOS-x64


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow for Electron builds to use the latest macOS runner image (macos-15) instead of macos-13 for x64 architecture builds.

## Key Changes
- Changed macOS build runner from `macos-13` to `macos-15`
- Updated the comment to reflect that macos-15 will cross-compile for x64 architecture instead of using a native Intel runner

## Details
This update modernizes the CI/CD pipeline to use a more recent macOS runner environment. The macos-15 runner will handle x64 cross-compilation, allowing the build process to target x64 architecture from the newer runner image.

https://claude.ai/code/session_01PRdQqPK9nJFuZ6q8sVa8Ba