### PR TITLE
Add actions write permission to build-electron workflow

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -15,6 +15,7 @@ on:
 
 # Add proper permissions for creating releases
 permissions:
+  actions: write
   contents: write
   packages: write
 


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow permissions to include the `actions: write` permission for the build-electron workflow.

## Changes
- Added `actions: write` permission to the workflow permissions configuration

## Details
This permission is necessary to allow the workflow to perform actions-related operations, such as creating or managing workflow artifacts and runs. The existing `contents: write` and `packages: write` permissions are retained.

https://claude.ai/code/session_01ANxWv7y2yc2iYqu4ExU9ZZ