### PR TITLE
Add blog post: "Browser Extensions Won't Save Your Privacy"

### DIFF
--- a/docs/blog/browser-extensions-wont-save-your-privacy.md
+++ b/docs/blog/browser-extensions-wont-save-your-privacy.md
@@ -1,0 +1,180 @@
+---
+title: "Browser Extensions Won't Save Your Privacy"
+description: "Privacy-focused extensions are the most common advice for staying safe online. But extensions themselves are a privacy and security risk most people overlook. Here's why bolting on privacy doesn't work."
+date: 2026-02-15
+author: nav0 team
+tags: [privacy, extensions, security, browsers]
+head:
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: article:published_time
+      content: "2026-02-15"
+  - - meta
+    - property: article:author
+      content: nav0 team
+  - - meta
+    - property: article:tag
+      content: privacy
+  - - meta
+    - property: article:tag
+      content: extensions
+  - - meta
+    - property: article:tag
+      content: security
+  - - meta
+    - property: article:tag
+      content: browsers
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "Browser Extensions Won't Save Your Privacy",
+        "description": "Privacy-focused extensions are the most common advice for staying safe online. But extensions themselves are a privacy and security risk most people overlook. Here's why bolting on privacy doesn't work.",
+        "datePublished": "2026-02-15",
+        "author": { "@type": "Organization", "name": "nav0 team", "url": "https://nav0.org" },
+        "publisher": { "@type": "Organization", "name": "nav0", "url": "https://nav0.org", "logo": { "@type": "ImageObject", "url": "https://nav0.org/logo.svg" } },
+        "mainEntityOfPage": "https://nav0.org/blog/browser-extensions-wont-save-your-privacy",
+        "keywords": ["privacy", "browser extensions", "security", "browser privacy", "extension permissions"]
+      }
+---
+
+# Browser Extensions Won't Save Your Privacy
+
+<p style="color: var(--vp-c-text-2); font-size: 0.9rem;">February 15, 2026 &middot; 8 min read</p>
+
+Go to any privacy forum, any "how to secure your browser" guide, any tech journalist's recommendations, and you'll find the same advice: install these five extensions. uBlock Origin. Privacy Badger. HTTPS Everywhere. NoScript. Cookie AutoDelete. Maybe a few more.
+
+The logic seems sound. Your browser is broken, so fix it with add-ons.
+
+But here's the problem nobody talks about: browser extensions are themselves a massive privacy and security risk. You're patching one hole by opening several others. And the fundamental approach — bolting privacy onto a browser that was designed to surveil you — is architecturally flawed.
+
+## The Permissions Problem
+
+When you install a browser extension, you grant it permissions. Most privacy and ad-blocking extensions require the most powerful permission available: **access to all your data on all websites**.
+
+Think about what that means. You're giving a piece of third-party code the ability to:
+
+- **Read every page you visit.** Every article, every search result, every banking page, every medical portal. The extension can see it all, in full, including data you type into forms.
+
+- **Modify page content.** Ad blockers work by rewriting pages to remove elements. That same capability can inject content, redirect links, or alter what you see.
+
+- **Monitor your browsing patterns.** Which sites you visit, when, how long you stay, what you click. The extension sees your complete browsing session in real time.
+
+- **Make network requests.** Extensions can phone home to their own servers, sending whatever data they've collected. Many do this for legitimate reasons like updating filter lists. But the mechanism is identical to exfiltration.
+
+You read the privacy policies of these extensions, right? You audited their source code? You checked that the version in the extension store matches the public repository?
+
+Almost nobody does.
+
+## Extensions Get Sold, and You Won't Know
+
+Here's a pattern that has played out repeatedly in the extension ecosystem: a developer builds a popular, legitimate extension. It gains hundreds of thousands or millions of users. Then the developer sells it.
+
+The new owner pushes an update. The extension now collects browsing history, injects affiliate links, or serves ads. Users don't notice because the extension already had the permissions it needed. No new permission prompt appears. The update installs silently.
+
+This isn't hypothetical. It has happened to extensions with millions of users:
+
+- **The Great Suspender**, a Chrome extension with over 2 million users, was sold to an unknown entity that injected tracking code. Google eventually removed it from the Chrome Web Store, but not before the compromised version had been running on millions of machines for months.
+
+- **Nano Adblocker and Nano Defender**, with over 300,000 users combined, were sold to new developers who added code to collect browsing data and manipulate browser sessions.
+
+- **Stylish**, a popular extension for customizing website appearances with over 2 million users, was caught collecting detailed browsing histories tied to unique user identifiers and sending them to a remote server.
+
+- Multiple coupon and deal-finding extensions have been documented collecting complete browsing histories and selling the data to analytics firms.
+
+The extension store model has a fundamental vulnerability: **ownership can transfer, but permissions persist.** You trusted the original developer. You have no relationship with whoever owns the code now.
+
+## The Extension Store Is Not Protecting You
+
+Google's Chrome Web Store, Mozilla's Add-ons site, and other extension marketplaces perform some level of review. But the review process is not equipped to catch sophisticated data collection.
+
+In 2024, researchers found over 280 Chrome extensions that were stealing user data, affecting over 80 million users. These extensions had passed Chrome Web Store review. Some had been available for years.
+
+The problem is structural:
+
+- **Automated review catches known malware patterns**, not novel data collection. An extension that sends your browsing history to a server but doesn't match a known malware signature will pass.
+
+- **Manual review is sparse.** Extension stores host hundreds of thousands of extensions. Thorough code review of every update to every extension is not feasible.
+
+- **Obfuscated code is common.** Extensions routinely minify and obfuscate their JavaScript. This is standard practice for performance but also makes malicious code harder to detect during review.
+
+- **Delayed payloads work.** An extension can pass review with clean code, then fetch and execute malicious code from a remote server after installation. Some extensions activate data collection only after reaching a certain user count.
+
+You're trusting a review process that has repeatedly failed to catch extensions actively stealing data from millions of users.
+
+## More Extensions, More Attack Surface
+
+Every extension you install increases your attack surface. This is a basic security principle: more code means more potential vulnerabilities.
+
+Privacy-focused users often run five, ten, or more extensions simultaneously. Each one:
+
+- **Runs with elevated privileges** in your browser process.
+- **Receives automatic updates** that install without your explicit approval.
+- **Can interact with other extensions** in unexpected ways, creating conflicts and gaps.
+- **Adds to your browser fingerprint.** Ironically, the extensions you install to protect your privacy make you more uniquely identifiable. Your specific combination of extensions, their configurations, and their effects on page behavior create a fingerprint that tracking scripts can detect.
+
+A 2024 study demonstrated that browser extensions are detectable by websites through timing attacks, DOM modifications, and resource loading patterns. The researchers could identify specific extensions and use the combination as a tracking vector. Running privacy extensions can make you *more* trackable, not less.
+
+## The Fundamental Architecture Problem
+
+The extension approach to privacy has a deeper flaw: it tries to fix the wrong layer.
+
+When you install a privacy extension in Chrome, you're running code that tries to block Chrome from doing what Chrome was designed to do. You're using Google's extension API to fight Google's tracking. You're operating within a sandbox that Google controls, using capabilities that Google grants, on a timeline that Google dictates.
+
+Google can and does change extension APIs in ways that break privacy tools. The transition from Manifest V2 to Manifest V3 in Chrome restricted the capabilities that ad blockers and privacy extensions rely on. Specifically, it limited the `webRequest` API that allowed extensions to intercept and modify network requests in real time, replacing it with a more limited `declarativeNetRequest` API.
+
+This isn't a conspiracy. It's an incentive structure. Google makes the vast majority of its revenue from advertising. Chrome extensions that block ads and tracking directly threaten that revenue. Google controls the platform these extensions run on. The long-term outcome is predictable.
+
+You can't sustainably protect your privacy by fighting against the platform you're running on.
+
+## What Actually Works
+
+Privacy shouldn't be a feature you bolt on. It should be an architectural decision.
+
+A browser that doesn't collect your data doesn't need an extension to stop it from collecting your data. A browser that doesn't phone home doesn't need an extension to block its network requests. A browser that doesn't run a built-in ad network doesn't need an ad blocker to fight it.
+
+### Build It In, Don't Bolt It On
+
+Tracking protection, HTTPS upgrades, fingerprinting resistance, and third-party cookie blocking should be built into the browser itself. When these features are part of the browser's core architecture, they work reliably, they can't be broken by extension API changes, and they don't add third-party code to your attack surface.
+
+### Stay Minimal
+
+A browser with fewer features has fewer things that can go wrong. No built-in shopping assistant means no need for an extension to block it. No news feed means no need for an extension to hide it. No telemetry means no need for an extension to disable it.
+
+The best defense isn't a longer list of countermeasures. It's a shorter list of threats.
+
+### Trust the Code, Not the Store
+
+Open-source software can be audited by anyone. You don't need to trust a review process that has repeatedly failed. You can read the code yourself, or rely on a community that does. When the browser itself is open source, there's nowhere to hide data collection.
+
+## If You Still Use Extensions
+
+If you're using a browser that requires extensions for basic privacy, at minimum:
+
+1. **Use as few extensions as possible.** Every extension is a risk. Only install what you genuinely need and actively use.
+
+2. **Prefer open-source extensions** with active, reputable maintainers. Check the repository, not just the store listing.
+
+3. **Review permissions critically.** If a calculator extension wants access to all your browsing data, something is wrong. But remember that even legitimate privacy extensions need broad permissions by design.
+
+4. **Watch for ownership changes.** If an extension is acquired by a new company, re-evaluate whether you trust the new owner. This information is rarely publicized.
+
+5. **Understand that extensions are a patch, not a solution.** They reduce some risks while introducing others. The net privacy improvement is smaller than most people assume.
+
+## The Uncomfortable Truth
+
+The browser extension ecosystem operates on the same trust model as the browsers themselves: you're handing broad access to your data to someone else and hoping they'll handle it responsibly.
+
+Privacy-focused extensions are, on average, far more trustworthy than the browsers they're installed on. Many are built by principled developers who genuinely care about user privacy. That's not the issue.
+
+The issue is the model itself. Any system where your privacy depends on trusting third-party code that can silently update, change ownership, and access everything you do online is fragile by design. It worked when extensions were simple and the stakes were low. Neither of those things is true anymore.
+
+The real solution isn't a better extension. It's a better browser — one where privacy is the architecture, not an add-on.
+
+---
+
+*nav0 is a minimal, privacy-focused browser with tracking protection, HTTPS upgrades, and fingerprinting resistance built in. No extensions required. It's open source, free, and collects zero data. [Get started](/guide/getting-started).*

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,6 +1,6 @@
 ---
 title: "nav0 Blog — Privacy, Browsers & the Open Web"
-description: "Thoughts on privacy, browsers, and the open web from the nav0 team. Articles about browser tracking, AI bloat, VPN security theater, and big tech browser control."
+description: "Thoughts on privacy, browsers, and the open web from the nav0 team. Articles about browser tracking, AI bloat, VPN security theater, extension risks, and big tech browser control."
 ---
 
 # Blog
@@ -8,6 +8,14 @@ description: "Thoughts on privacy, browsers, and the open web from the nav0 team
 Thoughts on privacy, browsers, and the open web.
 
 ---
+
+<div class="blog-post-item">
+  <a href="/blog/browser-extensions-wont-save-your-privacy">
+    <h2>Browser Extensions Won't Save Your Privacy</h2>
+  </a>
+  <div class="post-meta">February 15, 2026 &middot; 8 min read &middot; Security</div>
+  <p class="post-excerpt">Privacy-focused extensions are the most common advice for staying safe online. But extensions themselves are a privacy and security risk most people overlook. Here's why bolting on privacy doesn't work.</p>
+</div>
 
 <div class="blog-post-item">
   <a href="/blog/your-browser-is-watching-you">


### PR DESCRIPTION
## Summary
Added a new blog post discussing the privacy and security risks of browser extensions, and updated the blog index to feature this article.

## Changes Made
- **New blog post**: `docs/blog/browser-extensions-wont-save-your-privacy.md`
  - Comprehensive 8-minute article examining why privacy-focused extensions are not a reliable solution for browser privacy
  - Covers key topics: extension permissions, ownership transfers, extension store vulnerabilities, attack surface expansion, and architectural limitations
  - Includes structured metadata (OpenGraph tags, JSON-LD schema) for SEO and social sharing
  - Concludes with practical recommendations for users who still use extensions and advocates for privacy-by-design in browsers

- **Updated blog index**: `docs/blog/index.md`
  - Added new blog post to the top of the blog listing
  - Updated description to mention "extension risks" alongside existing topics
  - Includes post metadata (date, read time, category) and excerpt

## Notable Details
The article argues that browser extensions represent a fundamental architectural flaw in privacy protection—attempting to patch privacy issues through third-party code rather than building privacy into the browser itself. It references real-world examples of compromised extensions (The Great Suspender, Nano Adblocker, Stylish) and research findings about extension-based tracking vulnerabilities.

https://claude.ai/code/session_01JUrGi9JYRM8aySJHdQoQnu