### PR TITLE
Normalize version string format in build workflow

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -185,7 +185,9 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
-            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+            # Strip v prefix if present, then always add it back for consistency
+            VERSION="${INPUT_VERSION#v}"
+            echo "version=v${VERSION}" >> $GITHUB_OUTPUT
           else
             VERSION=$(node -p "require('./package.json').version")
             echo "version=v${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
This change ensures consistent version string formatting in the Electron build workflow by normalizing the version output to always include a "v" prefix, regardless of the input format.

## Key Changes
- Modified the version output step to strip any existing "v" prefix from the input version and then consistently add it back
- This ensures that whether a user provides "1.0.0" or "v1.0.0" as input, the output will always be "v1.0.0"
- Aligns the manual version input path with the existing behavior of the automatic version extraction from package.json

## Implementation Details
- Uses bash parameter expansion `${INPUT_VERSION#v}` to remove a leading "v" if present
- Reconstructs the version string with the "v" prefix: `v${VERSION}`
- This normalization prevents potential issues with inconsistent version formatting downstream in the build process

https://claude.ai/code/session_01LpcNiTU3u4V4vpW7npaGVq