### PR TITLE
Sync package.json version with release input before building

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -59,6 +59,21 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Set version in package.json
+        if: github.event.inputs.version != ''
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          VERSION="${INPUT_VERSION#v}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '${VERSION}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Updated package.json version to ${VERSION}"
+
       # Windows dependencies for electron-forge
       - name: Install Windows dependencies
         if: matrix.platform == 'win'


### PR DESCRIPTION
When a custom version is provided via workflow_dispatch, electron-forge still reads package.json to name artifacts. This caused a mismatch where the release tag was e.g. v0.0.2-alpha but artifact filenames contained 0.1.0 from package.json, breaking the Homebrew cask download URLs.

https://claude.ai/code/session_01LpcNiTU3u4V4vpW7npaGVq