### PR TITLE
Enable ES modules in docs directory

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
Configure the docs directory to use ES modules (ESM) as the default module system by adding a `package.json` file with the `"type": "module"` field.

## Changes
- Added `docs/package.json` with `"type": "module"` configuration to enable ES module support in the docs directory

## Details
This change allows JavaScript files in the docs directory to be treated as ES modules by default, enabling the use of `import`/`export` syntax instead of CommonJS `require()` statements. This is useful for maintaining consistency with modern JavaScript practices and aligning the docs tooling with the project's module system.

https://claude.ai/code/session_017ipA3L7DtEGCoNzSganm4C