### PR TITLE
Fix same CSS loading issues across all renderer HTML files and Option…

### DIFF
--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -187,12 +187,13 @@ export class AppWindow {
     this.getBrowserWindowInstance().setBounds(bounds);
   }
 
-  showOptionsMenuOverlay(): void {
+  async showOptionsMenuOverlay(): Promise<void> {
     this.hideCommandKOverlay();
     if(this.browserWindowInstance.contentView.children.indexOf(this.optionsMenuManager.getWebContentsViewInstance()) > -1){
       //already open
       return;
     }
+    await this.optionsMenuManager.whenReady();
     const parentBounds = this.browserWindowInstance.contentView.getBounds();
     this.optionsMenuManager.getWebContentsViewInstance().setBounds(parentBounds);
     this.browserWindowInstance.contentView.addChildView(this.optionsMenuManager.getWebContentsViewInstance());

--- a/src/main/browser/options-menu-manager.ts
+++ b/src/main/browser/options-menu-manager.ts
@@ -5,6 +5,7 @@ export class OptionsMenuManager {
   private appWindowId: string;
   private isPrivate: boolean;
   private partitionSetting: string;
+  private readyPromise: Promise<void>;
 
   constructor(appWindowId: string, isPrivate: boolean, partitionSetting: string) {
     this.appWindowId = appWindowId;
@@ -13,7 +14,7 @@ export class OptionsMenuManager {
     this.init();
   }
 
-  private async init(){
+  private init(){
     this.webContentsViewInstance = new WebContentsView({
       webPreferences: {
         preload: OPTIONS_MENU_PRELOAD_WEBPACK_ENTRY,
@@ -28,14 +29,21 @@ export class OptionsMenuManager {
       }
     });
 
+    this.readyPromise = new Promise<void>((resolve) => {
+      this.webContentsViewInstance.webContents.once('did-finish-load', () => resolve());
+    });
+
     this.webContentsViewInstance.webContents.setWindowOpenHandler(({ url }) => {
       return { action: 'deny' };
     });
 
-    // this.webContentsViewInstance.webContents.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36');
     this.webContentsViewInstance.webContents.loadURL(OPTIONS_MENU_WEBPACK_ENTRY);
 
     // this.webContentsViewInstance.webContents.openDevTools({ mode: 'detach' });
+  }
+
+  whenReady(): Promise<void> {
+    return this.readyPromise;
   }
 
   getWebContentsViewInstance(): WebContentsView {

--- a/src/renderer/browser-layout/index.html
+++ b/src/renderer/browser-layout/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>Nav0 Browser</title>
-  <link rel="stylesheet" src="styles/index.css">
+
 </head>
 <body>
   <div id="browser-layout-container" class="browser-layout-container">

--- a/src/renderer/options-menu/index.html
+++ b/src/renderer/options-menu/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
+
 </head>
 <body>
   <div>

--- a/src/renderer/pages/bookmarks/index.html
+++ b/src/renderer/pages/bookmarks/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
   <title>Bookmarks</title>
 </head>
 <body>

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
+
 </head>
 <body>
   This is the page for Browser Settings. //@todo - implement this.

--- a/src/renderer/pages/downloads/index.html
+++ b/src/renderer/pages/downloads/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
   <title>Downloads</title>
 </head>
 <body>

--- a/src/renderer/pages/history/index.html
+++ b/src/renderer/pages/history/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
   <title>Browsing History</title>
 </head>
 <body>

--- a/src/renderer/pages/new-tab/index.html
+++ b/src/renderer/pages/new-tab/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
-  <link rel="stylesheet" src="index.css">
   <title>New Tab</title>
 </head>
 <body>


### PR DESCRIPTION
…sMenuManager

Remove broken <link rel="stylesheet" src="..."> tags from all 7 remaining HTML templates. These used `src` instead of `href`, so the browser ignored them entirely — CSS was only loaded later via webpack's style-loader (JS injection), causing a brief flash of unstyled content.

Also add whenReady() guard to OptionsMenuManager (matching the CommandKOverlayManager pattern) to prevent showing the overlay before its content has finished loading.

https://claude.ai/code/session_01874hnEqDKV7T5X6sMtf4Cc