### PR TITLE
Wrap resetState script in IIFE to avoid const redeclaration error

### DIFF
--- a/src/main/browser/command-k-overlay-manager.ts
+++ b/src/main/browser/command-k-overlay-manager.ts
@@ -47,7 +47,7 @@ export class CommandKOverlayManager {
   }
 
   resetState(): void {
-    this.webContentsViewInstance.webContents.executeJavaScript(`
+    this.webContentsViewInstance.webContents.executeJavaScript(`(() => {
       const input = document.getElementById('search-input');
       if (input) {
         input.value = '';
@@ -56,7 +56,7 @@ export class CommandKOverlayManager {
       }
       document.querySelectorAll('.action-btn').forEach(b => b.classList.remove('primary'));
       document.querySelector('.action-btn[data-filter="all"]')?.classList.add('primary');
-    `).catch(() => {});
+    })()`).catch(() => {});
   }
 
   getWebContentsViewInstance(): WebContentsView {


### PR DESCRIPTION
Since the overlay is now reused instead of recreated, executeJavaScript runs in the same global context each time. Declaring `const input` twice in the same scope throws "Identifier 'input' has already been declared". Wrapping in an IIFE gives each invocation its own scope.

https://claude.ai/code/session_01874hnEqDKV7T5X6sMtf4Cc