### PR TITLE
Prevent Escape key from exiting fullscreen mode

### DIFF
--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -61,6 +61,11 @@ export class AppWindow {
       this.browserWindowInstance.on('closed', () => {
         this.browserWindowInstance = null;
       });
+
+      // Prevent Escape from exiting fullscreen
+      this.browserWindowInstance.on('leave-full-screen', () => {
+        this.browserWindowInstance?.setFullScreen(true);
+      });
     
       this.browserWindowInstance.webContents.on('did-finish-load', () => {
         const firstTab = this.createTab(InAppUrls.NEW_TAB);


### PR DESCRIPTION
## Summary
Added logic to prevent the Escape key from exiting fullscreen mode in the application window. When the browser window attempts to leave fullscreen, it is immediately returned to fullscreen state.

## Key Changes
- Added a `leave-full-screen` event listener to the browser window instance
- When the event is triggered, the window is automatically set back to fullscreen using `setFullScreen(true)`

## Implementation Details
The listener is attached during window initialization, ensuring that any attempt to exit fullscreen (including via the Escape key) will be intercepted and the fullscreen state will be restored. This provides a consistent fullscreen experience where users cannot accidentally exit fullscreen using keyboard shortcuts.

https://claude.ai/code/session_01AGvGyXDVHwxJEuZjPy3jdJ