### PR TITLE
Fix hero image overflowing viewport on desktop

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -56,6 +56,7 @@
     display: flex !important;
     align-items: center !important;
     gap: 2rem !important;
+    overflow: hidden !important;
   }
 
   .VPHero.has-image .main {
@@ -65,8 +66,8 @@
   }
 
   .VPHero.has-image .image {
-    flex-grow: 1 !important;
-    width: 60% !important;
+    flex: 1 1 0% !important;
+    min-width: 0 !important;
     max-width: none !important;
     min-height: auto !important;
   }


### PR DESCRIPTION
The hero layout used width: 40% + width: 60% + gap: 2rem which exceeded 100% and caused the image to overflow to the right. Replace explicit width: 60% with flex: 1 1 0% + min-width: 0 so the image column fills remaining space after the gap. Also add overflow: hidden on the container as a safety net.

https://claude.ai/code/session_01DrJqn6S5YpwVYhAXeRHX1t