### PR TITLE
Fix hero image overflowing viewport — root cause found

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -54,13 +54,13 @@
 @media (min-width: 960px) {
   .VPHero.has-image .container {
     display: flex !important;
+    flex-direction: row !important;
     align-items: center !important;
     gap: 2rem !important;
-    overflow: hidden !important;
   }
 
   .VPHero.has-image .main {
-    flex-shrink: 0 !important;
+    flex: 0 0 auto !important;
     width: 40% !important;
     max-width: 440px !important;
   }
@@ -69,18 +69,26 @@
     flex: 1 1 0% !important;
     min-width: 0 !important;
     max-width: none !important;
-    min-height: auto !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    overflow: hidden !important;
   }
 
   .VPHero .image-container {
+    display: block !important;
+    position: relative !important;
     transform: none !important;
     width: 100% !important;
     max-width: 100% !important;
+    height: auto !important;
     margin: 0 !important;
   }
 
   .VPHero .VPImage.image-src {
+    display: block !important;
     position: relative !important;
+    top: 0 !important;
+    left: 0 !important;
     z-index: 1;
     transform: none !important;
     border-radius: 16px;
@@ -92,7 +100,7 @@
   }
 
   .VPHero .image-bg {
-    transform: scale(1.6) !important;
+    transform: translate(-50%, -50%) scale(1.6) !important;
     opacity: 0.5 !important;
   }
 }
@@ -107,6 +115,8 @@
 
   .VPHero .VPImage {
     position: relative !important;
+    top: 0 !important;
+    left: 0 !important;
     z-index: 1;
     transform: none !important;
     width: 100% !important;


### PR DESCRIPTION
VitePress's default hero image uses position:absolute + top:50% + left:50% + transform:translate(-50%,-50%) to center a small logo. Our CSS overrode position to relative and transform to none, but never reset top/left. This left the image shifted right by 50% of its container width (~340px on a 1440px viewport), causing it to overflow the viewport.

Root cause fix:
- Add top:0 + left:0 to both desktop and mobile image overrides

Additional hardening:
- Use flex:0 0 auto on .main (kills inherited flex-grow:1)
- Use display:block + height:auto on .image-container (overrides VitePress's display:flex + height:100% which misbehaves)
- Fix .image-bg transform to translate(-50%,-50%) scale(1.6) (was losing the centering translate)
- Move overflow:hidden from container to .image div (clips the scaled .image-bg without affecting .main)

https://claude.ai/code/session_01DrJqn6S5YpwVYhAXeRHX1t