### PR TITLE
Disable macOS Local Network permission dialog triggers

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,14 @@ import { app, ipcMain } from 'electron';
 import { AppWindowManager } from './browser/app-window-manager';
 import { DataStoreManager } from './database/data-store-manager';
 
+// Disable Chromium features that trigger macOS "Local Network" permission dialog.
+// These features use mDNS/Bonjour for device discovery, which is unnecessary for
+// a privacy-focused browser and causes an unwanted system permission prompt on macOS.
+app.commandLine.appendSwitch('disable-features', [
+  'MediaRouter',
+  'DialMediaRouteProvider',
+  'GlobalMediaControls',
+].join(','));
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling
 if (require('electron-squirrel-startup')) {


### PR DESCRIPTION
## Summary
Disable Chromium features that trigger the macOS "Local Network" permission dialog on application startup. These features are unnecessary for the browser's functionality and create an unwanted user experience.

## Key Changes
- Disabled `MediaRouter` feature which uses mDNS/Bonjour for device discovery
- Disabled `DialMediaRouteProvider` feature 
- Disabled `GlobalMediaControls` feature
- Added command-line switch configuration at app initialization to prevent these features from loading

## Implementation Details
The changes are applied via `app.commandLine.appendSwitch()` during the main process initialization, before any window creation or IPC setup occurs. This ensures the features are disabled before Chromium attempts to use them, preventing the system permission prompt from appearing on macOS.

https://claude.ai/code/session_01G5dHkgs6QszHC9nn3qFBWi