### PR TITLE
Fix Command K overlay spacing and focus handling

### DIFF
--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -242,6 +242,7 @@ export class AppWindow {
     this.commandKOverlayManager.getWebContentsViewInstance().setBounds(parentBounds);
     this.browserWindowInstance.contentView.addChildView(this.commandKOverlayManager.getWebContentsViewInstance());
     this.commandKOverlayManager.resetState();
+    this.commandKOverlayManager.getWebContentsViewInstance().webContents.focus();
   }
   hideCommandKOverlay(): void {
     if(this.commandKOverlayManager && this.browserWindowInstance.contentView.children.indexOf(this.commandKOverlayManager.getWebContentsViewInstance()) > -1){

--- a/src/renderer/pages/command-k/index.css
+++ b/src/renderer/pages/command-k/index.css
@@ -89,6 +89,7 @@ body {
 .action-btn {
   display: flex;
   align-items: center;
+  gap: 5px;
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
@@ -106,7 +107,6 @@ body {
 }
 
 .action-btn i {
-  margin-right: 6px;
   color: var(--primary-color);
 }
 


### PR DESCRIPTION
## Summary
This PR improves the Command K overlay UI and interaction by refactoring button spacing and ensuring the overlay receives focus when displayed.

## Key Changes
- **CSS Refactoring**: Replaced individual `margin-right` on action button icons with a consistent `gap` property on the flex container for better spacing consistency
- **Focus Management**: Added explicit focus call to the Command K overlay's web contents when the overlay is shown, ensuring keyboard input is properly captured

## Implementation Details
- The gap-based spacing approach is more maintainable and aligns with modern CSS flexbox best practices
- The focus call ensures that when the Command K overlay is displayed, it immediately receives keyboard focus without requiring a manual click

https://claude.ai/code/session_018ifQPDhk18W5d1xrP7q9TY