### PR TITLE
Add recently closed tabs/windows feature with History submenu

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -148,6 +148,11 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly APPLY_SETTINGS = "browser:apply-settings";
   public static readonly GET_STORAGE_ESTIMATE = "browser:get-storage-estimate";
 
+  // Recently closed
+  public static readonly FETCH_RECENTLY_CLOSED_TABS = "browser:fetch-recently-closed-tabs";
+  public static readonly FETCH_RECENTLY_CLOSED_WINDOWS = "browser:fetch-recently-closed-windows";
+  public static readonly REOPEN_CLOSED_WINDOW = "browser:reopen-closed-window";
+
   // Permission system
   public static readonly PERMISSION_PROMPT_RESPONSE = "browser:permission-prompt-response";
   public static readonly FETCH_PERMISSIONS = "browser:fetch-permissions";
@@ -180,6 +185,7 @@ export abstract class MainToRendererEventsForBrowserIPC {
 export abstract class DataStoreConstants {
   public static readonly DEFAULT_KEY = 'default';
   public static readonly BROWSER_SETTINGS = "browser-settings";
+  public static readonly RECENTLY_CLOSED_WINDOWS = "recently-closed-windows";
 }
 
 export abstract class RendererToMainEventsForDataStoreIPC {

--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -49,6 +49,16 @@ export abstract class AppMenuManager {
             await activeWindow.createTab(`file://${result.filePaths[0]}`, true);
           }},
           {type: 'separator' as const},
+          {label: 'Reopen Closed Tab', accelerator: 'CmdOrCtrl+Shift+T', click: async() => {
+            const activeWindow = AppWindowManager.getActiveWindow();
+            if (activeWindow && !activeWindow.isPrivate) {
+              const closedTab = activeWindow.popRecentlyClosedTab();
+              if (closedTab) {
+                await activeWindow.createTab(closedTab.url, true);
+              }
+            }
+          }},
+          {type: 'separator' as const},
           {label: 'Close Tab', click: async() => { AppWindowManager.getActiveWindow().closeTab(AppWindowManager.getActiveWindow().getActiveTabId(), true); }},
           {label: 'Close Window', click: async() => { AppWindowManager.closeWindow(AppWindowManager.getActiveWindowId()); }},
         ]

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -7,6 +7,7 @@ import { DatabaseManager } from "../database/database-manager";
 import { SearchEngine } from "../web/search-engine";
 import { PermissionManager, PermissionRequest } from "./permission-manager";
 import { PermissionPromptData } from "./permission-prompt-overlay-manager";
+import { RecentlyClosedManager } from "./recently-closed-manager";
 
 export abstract class AppWindowManager {
   private static windows: Map<string, AppWindow>;
@@ -406,6 +407,40 @@ export abstract class AppWindowManager {
       const fileUrl = `file://${filePath}`;
       await window.createTab(fileUrl, true);
       return fileUrl;
+    });
+
+    // Recently closed tabs & windows
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.FETCH_RECENTLY_CLOSED_TABS, async (event, appWindowId: string) => {
+      const window = AppWindowManager.getWindowById(appWindowId);
+      if (window && !window.isPrivate) {
+        return RecentlyClosedManager.getGlobalRecentlyClosedTabs();
+      }
+      return [];
+    });
+
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.FETCH_RECENTLY_CLOSED_WINDOWS, async () => {
+      return RecentlyClosedManager.getClosedWindows();
+    });
+
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.REOPEN_CLOSED_WINDOW, async (event, closedWindowId: string) => {
+      const closedWindows = RecentlyClosedManager.getClosedWindows();
+      const windowRecord = closedWindows.find(w => w.id === closedWindowId);
+      if (windowRecord && windowRecord.tabs.length > 0) {
+        const newWindow = AppWindowManager.createWindow(false);
+        // Wait for the window's did-finish-load which creates the first tab
+        newWindow.getBrowserWindowInstance().webContents.once('did-finish-load', async () => {
+          // Navigate the first (auto-created) tab to the first URL
+          const firstTab = newWindow.getActiveTab();
+          if (firstTab) {
+            firstTab.navigate(windowRecord.tabs[0].url);
+          }
+          // Create remaining tabs
+          for (let i = 1; i < windowRecord.tabs.length; i++) {
+            await newWindow.createTab(windowRecord.tabs[i].url, false);
+          }
+          RecentlyClosedManager.removeClosedWindow(closedWindowId);
+        });
+      }
     });
 
   }

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -8,6 +8,8 @@ import { DownloadManager } from "./download-manager";
 import { PermissionManager } from "./permission-manager";
 import { PermissionPromptOverlayManager, PermissionPromptData } from "./permission-prompt-overlay-manager";
 import { FindInPageManager } from "./find-in-page-manager";
+import { RecentlyClosedManager } from "./recently-closed-manager";
+import { ClosedTabRecord } from "../../types/recently-closed-types";
 import type { Database as DB } from 'better-sqlite3';
 
 export class AppWindow {
@@ -22,6 +24,8 @@ export class AppWindow {
   private permissionPromptOverlayManager: PermissionPromptOverlayManager | null = null;
   private findInPageManager: FindInPageManager | null = null;
   private database: DB;
+  private recentlyClosedTabs: ClosedTabRecord[] = [];
+  private closedWindowRecorded = false;
 
   constructor(isPrivate = false, database: DB) {
     this.isPrivate = isPrivate;
@@ -71,6 +75,17 @@ export class AppWindow {
       // so their resume metadata can be persisted to the DB
       this.browserWindowInstance.on('close', () => {
         DownloadManager.pauseAllDownloads();
+
+        // Record closed window state for "Recently Closed Windows"
+        if (!this.isPrivate && !this.closedWindowRecorded) {
+          this.closedWindowRecorded = true;
+          const tabInfos = this.getTabs().map(tab => ({
+            url: tab.getUrl(),
+            title: tab.getTitle(),
+            faviconUrl: tab.getFaviconUrl(),
+          }));
+          RecentlyClosedManager.recordClosedWindow(tabInfos, this.isPrivate);
+        }
       });
 
       this.browserWindowInstance.on('closed', () => {
@@ -149,6 +164,21 @@ export class AppWindow {
   closeTab(id: string, isUserInitiated = true): void {
     const tab = this.tabs.get(id);
     if (tab) {
+      // Capture tab state before closing (skip private and internal pages)
+      if (!this.isPrivate) {
+        const url = tab.getUrl();
+        const title = tab.getTitle();
+        const faviconUrl = tab.getFaviconUrl();
+        if (url && !url.startsWith(InAppUrls.PREFIX) && url !== '') {
+          const record: ClosedTabRecord = { url, title, faviconUrl, closedAt: Date.now() };
+          this.recentlyClosedTabs.push(record);
+          if (this.recentlyClosedTabs.length > 20) {
+            this.recentlyClosedTabs.shift();
+          }
+          RecentlyClosedManager.addClosedTab(record);
+        }
+      }
+
       PermissionManager.clearSessionPermissionsForTab(id);
       tab.getWebContentsViewInstance().removeAllListeners();
       tab.getWebContentsViewInstance().webContents.close();
@@ -189,6 +219,10 @@ export class AppWindow {
 
   getTabs(): Tab[] {
     return Array.from(this.tabs.values());
+  }
+
+  popRecentlyClosedTab(): ClosedTabRecord | null {
+    return this.recentlyClosedTabs.pop() || null;
   }
 
   getActiveTabId(): string | null {

--- a/src/main/browser/recently-closed-manager.ts
+++ b/src/main/browser/recently-closed-manager.ts
@@ -1,0 +1,53 @@
+import { v4 as uuid } from "uuid";
+import { DataStoreConstants } from "../../constants/app-constants";
+import { DataStoreManager } from "../database/data-store-manager";
+import { ClosedTabRecord, ClosedWindowRecord, ClosedWindowTabInfo } from "../../types/recently-closed-types";
+
+export abstract class RecentlyClosedManager {
+  private static readonly MAX_CLOSED_WINDOWS = 3;
+  private static readonly MAX_GLOBAL_CLOSED_TABS = 10;
+
+  private static globalRecentlyClosedTabs: ClosedTabRecord[] = [];
+
+  public static addClosedTab(tab: ClosedTabRecord): void {
+    RecentlyClosedManager.globalRecentlyClosedTabs.unshift(tab);
+    if (RecentlyClosedManager.globalRecentlyClosedTabs.length > RecentlyClosedManager.MAX_GLOBAL_CLOSED_TABS) {
+      RecentlyClosedManager.globalRecentlyClosedTabs.pop();
+    }
+  }
+
+  public static getGlobalRecentlyClosedTabs(): ClosedTabRecord[] {
+    return RecentlyClosedManager.globalRecentlyClosedTabs.slice(0, RecentlyClosedManager.MAX_GLOBAL_CLOSED_TABS);
+  }
+
+  public static recordClosedWindow(tabs: ClosedWindowTabInfo[], isPrivate: boolean): void {
+    if (isPrivate) return;
+
+    const validTabs = tabs.filter(t => t.url && !t.url.startsWith('nav0://') && t.url !== '');
+    if (validTabs.length === 0) return;
+
+    const record: ClosedWindowRecord = {
+      id: uuid(),
+      tabs: validTabs,
+      tabCount: validTabs.length,
+      closedAt: Date.now(),
+    };
+
+    const existing = RecentlyClosedManager.getClosedWindows();
+    existing.unshift(record);
+    const trimmed = existing.slice(0, RecentlyClosedManager.MAX_CLOSED_WINDOWS);
+
+    DataStoreManager.set(DataStoreConstants.RECENTLY_CLOSED_WINDOWS, trimmed);
+  }
+
+  public static getClosedWindows(): ClosedWindowRecord[] {
+    const data = DataStoreManager.get(DataStoreConstants.RECENTLY_CLOSED_WINDOWS);
+    return Array.isArray(data) ? data : [];
+  }
+
+  public static removeClosedWindow(id: string): void {
+    const existing = RecentlyClosedManager.getClosedWindows();
+    const filtered = existing.filter(w => w.id !== id);
+    DataStoreManager.set(DataStoreConstants.RECENTLY_CLOSED_WINDOWS, filtered);
+  }
+}

--- a/src/main/database/data-store-manager.ts
+++ b/src/main/database/data-store-manager.ts
@@ -23,6 +23,7 @@ export abstract class DataStoreManager {
 
   private static initStores(): void {
     DataStoreManager.stores.set(DataStoreConstants.BROWSER_SETTINGS, new Store({ name: DataStoreConstants.BROWSER_SETTINGS, defaults: {'default' : DataStoreManager.getDefaultValue(DataStoreConstants.BROWSER_SETTINGS)}  as Record<string, any>}));
+    DataStoreManager.stores.set(DataStoreConstants.RECENTLY_CLOSED_WINDOWS, new Store({ name: DataStoreConstants.RECENTLY_CLOSED_WINDOWS, defaults: {'default' : DataStoreManager.getDefaultValue(DataStoreConstants.RECENTLY_CLOSED_WINDOWS)} as Record<string, any>}));
   }
 
 
@@ -124,6 +125,9 @@ export abstract class DataStoreManager {
     switch (storeName) {
       case DataStoreConstants.BROWSER_SETTINGS:
         returnValue = { ...DEFAULT_BROWSER_SETTINGS };
+        break;
+      case DataStoreConstants.RECENTLY_CLOSED_WINDOWS:
+        returnValue = [];
         break;
       default:
         break;

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -378,6 +378,8 @@ export abstract class SettingsEnforcer {
       } else {
         const result = db.prepare("DELETE FROM browsingHistory").run();
         deletedCount += result.changes;
+        // Also clear recently closed windows when clearing all history
+        DataStoreManager.set(DataStoreConstants.RECENTLY_CLOSED_WINDOWS, []);
       }
     }
 

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -166,6 +166,17 @@ export function init(){
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.GET_STORAGE_ESTIMATE);
     },
 
+    // Recently closed
+    fetchRecentlyClosedTabs: async (appWindowId: string) => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.FETCH_RECENTLY_CLOSED_TABS, appWindowId);
+    },
+    fetchRecentlyClosedWindows: async () => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.FETCH_RECENTLY_CLOSED_WINDOWS);
+    },
+    reopenClosedWindow: async (closedWindowId: string) => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.REOPEN_CLOSED_WINDOW, closedWindowId);
+    },
+
     // Event listeners
     onNewTabCreated: (callback: (tab: {id: string, url: string, title: string}) => void) => {
       ipcRenderer.on(MainToRendererEventsForBrowserIPC.NEW_TAB_CREATED, (_event, tab) => callback(tab));

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -63,6 +63,11 @@ declare global {
       fetchOpenTabs: (appWindowId: string) => Promise<Array<{id: string, title: string, url: string, faviconUrl: string | null}>>;
       toggleReaderMode: (appWindowId: string, tabId: string) => Promise<any>;
 
+      // Recently closed
+      fetchRecentlyClosedTabs: (appWindowId: string) => Promise<Array<{ url: string; title: string; faviconUrl: string | null; closedAt: number }>>;
+      fetchRecentlyClosedWindows: () => Promise<Array<{ id: string; tabs: Array<{ url: string; title: string; faviconUrl: string | null }>; tabCount: number; closedAt: number }>>;
+      reopenClosedWindow: (closedWindowId: string) => Promise<any>;
+
       // Event listeners
       onNewTabCreated: (callback: (tab: {id: string, url: string, title: string}) => void) => void;
       onTabActivated: (callback: (tab: {id: string, url: string}) => void) => void;

--- a/src/renderer/options-menu/index.css
+++ b/src/renderer/options-menu/index.css
@@ -114,3 +114,89 @@ body {
   max-width: 50px;
   /* display: none; */
 }
+
+/* History submenu */
+.history-submenu {
+  width: 300px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.submenu-section-header {
+  padding: 6px 16px 2px 16px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  user-select: none;
+}
+
+.submenu-empty-state {
+  padding: 4px 16px;
+  font-size: 12px;
+  color: var(--text-light);
+  font-style: italic;
+}
+
+.recently-closed-tab-item {
+  display: flex;
+  align-items: center;
+  padding: 4px 16px;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  gap: 8px;
+}
+
+.recently-closed-tab-item:hover {
+  background-color: var(--bg-hover);
+}
+
+.recently-closed-tab-item .tab-favicon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.recently-closed-tab-item .tab-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.recently-closed-window-item {
+  display: flex;
+  align-items: center;
+  padding: 4px 16px;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  gap: 8px;
+}
+
+.recently-closed-window-item:hover {
+  background-color: var(--bg-hover);
+}
+
+.recently-closed-window-item .window-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.recently-closed-window-item .window-info {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.recently-closed-window-item .tab-count {
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-light);
+}

--- a/src/renderer/options-menu/index.html
+++ b/src/renderer/options-menu/index.html
@@ -47,10 +47,35 @@
         <span id="downloads-shortcut"  class="keyboard-shortcut"></span>
       </div>
       
-      <div class="dropdown-item" id="history-option">
+      <div class="dropdown-item has-submenu" id="history-menu-item">
         <i data-lucide="clock" width="16" height="16"></i>
         <span class="dropdown-item-text">History</span>
-        <span id="history-shortcut"  class="keyboard-shortcut"></span>
+        <i data-lucide="chevron-right" class="submenu-indicator" width="14" height="14"></i>
+
+        <div class="submenu history-submenu" id="history-submenu">
+          <!-- Section 1: Show All History -->
+          <div class="dropdown-item" id="history-show-all-option">
+            <i data-lucide="clock" width="16" height="16"></i>
+            <span class="dropdown-item-text">Show All History</span>
+            <span id="history-shortcut" class="keyboard-shortcut"></span>
+          </div>
+
+          <div class="divider"></div>
+
+          <!-- Section 2: Recently Closed Tabs -->
+          <div class="submenu-section-header">Recently Closed</div>
+          <div id="recently-closed-tabs-container">
+            <div class="submenu-empty-state" id="no-recently-closed-tabs">No recently closed tabs</div>
+          </div>
+
+          <div class="divider"></div>
+
+          <!-- Section 3: Recently Closed Windows -->
+          <div class="submenu-section-header">Recently Closed Windows</div>
+          <div id="recently-closed-windows-container">
+            <div class="submenu-empty-state" id="no-recently-closed-windows">No recently closed windows</div>
+          </div>
+        </div>
       </div>
     
       <div class="dropdown-item" id="bookmarks-option">

--- a/src/renderer/options-menu/options-menu-manager.ts
+++ b/src/renderer/options-menu/options-menu-manager.ts
@@ -20,7 +20,7 @@ export class OptionsMenuManager {
     if(window.BrowserAPI.platform === 'darwin'){
       document.getElementById('new-tab-shortcut').textContent = '⌘+T';
       document.getElementById('new-window-shortcut').textContent = '⌘+N';
-      document.getElementById('new-private-window-shortcut').textContent = '⌘+⇧+T';
+      document.getElementById('new-private-window-shortcut').textContent = '⌘+⇧+N';
       document.getElementById('find-in-page-shortcut').textContent = '⌘+F';
       document.getElementById('downloads-shortcut').textContent = '⌘+⇧+D';
       document.getElementById('history-shortcut').textContent = '⌘+⇧+H';
@@ -29,7 +29,7 @@ export class OptionsMenuManager {
     } else {
       document.getElementById('new-tab-shortcut').textContent = 'Ctrl+T';
       document.getElementById('new-window-shortcut').textContent = 'Ctrl+N';
-      document.getElementById('new-private-window-shortcut').textContent = 'Ctrl+⇧+T';
+      document.getElementById('new-private-window-shortcut').textContent = 'Ctrl+⇧+N';
       document.getElementById('find-in-page-shortcut').textContent = 'Ctrl+F';
       document.getElementById('downloads-shortcut').textContent = 'Ctrl+⇧+D';
       document.getElementById('history-shortcut').textContent = 'Ctrl+⇧+H';
@@ -67,8 +67,15 @@ export class OptionsMenuManager {
       await window.BrowserAPI.createTab(this.appWindowId, InAppUrls.DOWNLOADS, true);
     });
 
-    this.optionsElement?.querySelector('#history-option')?.addEventListener('click', async () => {
+    this.optionsElement?.querySelector('#history-show-all-option')?.addEventListener('click', async () => {
       await window.BrowserAPI.createTab(this.appWindowId, InAppUrls.HISTORY, true);
+    });
+
+    // Populate history submenu on hover
+    const historyMenuItem = this.optionsElement?.querySelector('#history-menu-item');
+    historyMenuItem?.addEventListener('mouseenter', async () => {
+      await this.populateRecentlyClosedTabs();
+      await this.populateRecentlyClosedWindows();
     });
 
     this.optionsElement?.querySelector('#bookmarks-option')?.addEventListener('click', async () => {
@@ -84,6 +91,113 @@ export class OptionsMenuManager {
       await window.BrowserAPI.showAboutPanel();
     });
 
+  }
+
+  private async populateRecentlyClosedTabs(): Promise<void> {
+    const container = document.getElementById('recently-closed-tabs-container');
+    const emptyState = document.getElementById('no-recently-closed-tabs');
+    if (!container) return;
+
+    // Clear existing dynamic entries
+    container.querySelectorAll('.recently-closed-tab-item').forEach(el => el.remove());
+
+    if (window.BrowserAPI.isPrivate) {
+      if (emptyState) emptyState.style.display = 'block';
+      return;
+    }
+
+    const closedTabs = await window.BrowserAPI.fetchRecentlyClosedTabs(this.appWindowId);
+
+    if (!closedTabs || closedTabs.length === 0) {
+      if (emptyState) emptyState.style.display = 'block';
+      return;
+    }
+
+    if (emptyState) emptyState.style.display = 'none';
+
+    for (const tab of closedTabs) {
+      const item = document.createElement('div');
+      item.className = 'recently-closed-tab-item';
+
+      if (tab.faviconUrl) {
+        const favicon = document.createElement('img');
+        favicon.className = 'tab-favicon';
+        favicon.src = tab.faviconUrl;
+        favicon.onerror = () => { favicon.style.display = 'none'; };
+        item.appendChild(favicon);
+      }
+
+      const title = document.createElement('span');
+      title.className = 'tab-title';
+      title.textContent = tab.title || tab.url;
+      title.title = tab.url;
+      item.appendChild(title);
+
+      item.addEventListener('click', async () => {
+        await window.BrowserAPI.createTab(this.appWindowId, tab.url, true);
+        await window.BrowserAPI.hideOptionsMenu(this.appWindowId);
+      });
+
+      container.appendChild(item);
+    }
+  }
+
+  private async populateRecentlyClosedWindows(): Promise<void> {
+    const container = document.getElementById('recently-closed-windows-container');
+    const emptyState = document.getElementById('no-recently-closed-windows');
+    if (!container) return;
+
+    // Clear existing dynamic entries
+    container.querySelectorAll('.recently-closed-window-item').forEach(el => el.remove());
+
+    if (window.BrowserAPI.isPrivate) {
+      if (emptyState) emptyState.style.display = 'block';
+      return;
+    }
+
+    const closedWindows = await window.BrowserAPI.fetchRecentlyClosedWindows();
+
+    if (!closedWindows || closedWindows.length === 0) {
+      if (emptyState) emptyState.style.display = 'block';
+      return;
+    }
+
+    if (emptyState) emptyState.style.display = 'none';
+
+    for (const win of closedWindows) {
+      const item = document.createElement('div');
+      item.className = 'recently-closed-window-item';
+
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'window-icon';
+      iconSpan.textContent = '🪟';
+      item.appendChild(iconSpan);
+
+      // Build display: show domains from tabs
+      const domains = win.tabs
+        .map((t: { url: string }) => { try { return new URL(t.url).hostname; } catch { return null; } })
+        .filter(Boolean)
+        .slice(0, 3);
+      const displayText = domains.join(', ');
+
+      const info = document.createElement('span');
+      info.className = 'window-info';
+      info.textContent = displayText || 'Window';
+      info.title = win.tabs.map((t: { title: string }) => t.title).join(', ');
+      item.appendChild(info);
+
+      const count = document.createElement('span');
+      count.className = 'tab-count';
+      count.textContent = `${win.tabCount} tab${win.tabCount !== 1 ? 's' : ''}`;
+      item.appendChild(count);
+
+      item.addEventListener('click', async () => {
+        await window.BrowserAPI.reopenClosedWindow(win.id);
+        await window.BrowserAPI.hideOptionsMenu(this.appWindowId);
+      });
+
+      container.appendChild(item);
+    }
   }
   public toggleOptionsVisibility(): void {
     this.optionsElement?.classList.toggle('show');

--- a/src/types/recently-closed-types.ts
+++ b/src/types/recently-closed-types.ts
@@ -1,0 +1,19 @@
+export type ClosedTabRecord = {
+  url: string;
+  title: string;
+  faviconUrl: string | null;
+  closedAt: number;
+};
+
+export type ClosedWindowTabInfo = {
+  url: string;
+  title: string;
+  faviconUrl: string | null;
+};
+
+export type ClosedWindowRecord = {
+  id: string;
+  tabs: ClosedWindowTabInfo[];
+  tabCount: number;
+  closedAt: number;
+};


### PR DESCRIPTION
- Add Cmd+Shift+T shortcut to reopen last closed tab (per-window LIFO stack)
- Convert History menu item to submenu with 3 sections:
  1. Show All History (existing behavior)
  2. Recently Closed tabs (max 10, in-memory, excludes private mode)
  3. Recently Closed Windows (max 3, persisted to disk via electron-store)
- Clicking a closed tab reopens it; clicking a closed window restores all its tabs
- Closed windows persist across app restarts for session recovery
- Clear recently closed windows when browsing history is cleared
- Fix incorrect shortcut display for New Private Window (was ⌘+⇧+T, now ⌘+⇧+N)