### PR TITLE
Fix GitHub repository URL in performance benchmark blog post

### DIFF
--- a/docs/blog/nav0-vs-chrome-performance-benchmark.md
+++ b/docs/blog/nav0-vs-chrome-performance-benchmark.md
@@ -250,7 +250,7 @@ If you care about system responsiveness, fewer processes means less OS overhead.
 
 ## Try It Yourself
 
-The test script is [open source in our repository](https://github.com/user/nav0-browser/blob/main/tests/performance/browser-perf-test-mac.js). If you have a Mac with Chrome and nav0 installed, you can reproduce these results in about 15 minutes. We believe in showing our work, not just making claims.
+The test script is [open source in our repository](https://github.com/nav0-org/nav0-browser/blob/main/tests/performance/browser-perf-test-mac.js). If you have a Mac with Chrome and nav0 installed, you can reproduce these results in about 15 minutes. We believe in showing our work, not just making claims.
 
 The numbers speak for themselves. Nav0 isn't just a little lighter than Chrome — it's a fundamentally different approach to building a browser. No telemetry tax, no feature bloat, no background processes doing work you never asked for.
 


### PR DESCRIPTION
## Summary
Corrected the GitHub repository URL in the performance benchmark blog post to point to the correct organization namespace.

## Changes
- Updated the repository URL from `https://github.com/user/nav0-browser/...` to `https://github.com/nav0-org/nav0-browser/...`
- This ensures the link to the open source test script correctly references the nav0-org organization

## Details
The blog post references an open source test script that readers can use to reproduce the performance benchmark results. The URL had an incorrect organization name (`user` instead of `nav0-org`), which would have resulted in a broken link. This fix ensures readers can actually access the referenced test script.

https://claude.ai/code/session_01TcVciVFSNZyLbhGHxshq1b