### PR TITLE
Refactor release notes into individual pages with dynamic sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,39 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+function getReleaseSidebar() {
+  const releasesDir = resolve(dirname(fileURLToPath(import.meta.url)), '../releases')
+  const files = readdirSync(releasesDir).filter(f => f.endsWith('.md') && f !== 'index.md')
+
+  const releases = files.map(file => {
+    const content = readFileSync(resolve(releasesDir, file), 'utf-8')
+    const match = content.match(/^---\n([\s\S]*?)\n---/)
+    if (!match) return null
+
+    const frontmatter = match[1]
+    const titleMatch = frontmatter.match(/title:\s*["'](.+?)["']/)
+    const dateMatch = frontmatter.match(/date:\s*(\S+)/)
+
+    return {
+      text: titleMatch?.[1] || file.replace('.md', ''),
+      date: dateMatch?.[1] || '',
+      link: `/releases/${file.replace('.md', '')}`
+    }
+  }).filter((r): r is { text: string; date: string; link: string } => r !== null)
+
+  releases.sort((a, b) => +new Date(b.date) - +new Date(a.date))
+
+  return [
+    {
+      text: 'Release Notes',
+      items: [
+        { text: 'All Releases', link: '/releases/' },
+        ...releases.map(({ text, link }) => ({ text, link }))
+      ]
+    }
+  ]
+}
+
 function getBlogSidebar() {
   const blogDir = resolve(dirname(fileURLToPath(import.meta.url)), '../blog')
   const files = readdirSync(blogDir).filter(f => f.endsWith('.md') && f !== 'index.md')
@@ -191,20 +224,7 @@ export default defineConfig({
         }
       ],
       '/blog/': getBlogSidebar(),
-      '/releases/': [
-        {
-          text: 'Release Notes',
-          items: [
-            { text: 'All Releases', link: '/releases/' },
-            { text: 'v0.0.6', link: '/releases/#v0-0-6' },
-            { text: 'v0.0.5-alpha', link: '/releases/#v0-0-5-alpha' },
-            { text: 'v0.0.4', link: '/releases/#v0-0-4' },
-            { text: 'v0.0.3-alpha', link: '/releases/#v0-0-3-alpha' },
-            { text: 'v0.0.2-alpha', link: '/releases/#v0-0-2-alpha' },
-            { text: '0.0.1-alpha', link: '/releases/#v0-0-1-alpha' },
-          ]
-        }
-      ]
+      '/releases/': getReleaseSidebar()
     },
 
     socialLinks: [

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -343,6 +343,53 @@
   line-height: 1.6;
 }
 
+/* ========== Release List Page ========== */
+.release-list-item {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.release-list-item:last-child {
+  border-bottom: none;
+}
+
+.release-list-item a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.release-list-item h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  border-top: none;
+  padding-top: 0;
+}
+
+.release-list-item h2:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.release-list-item .release-meta {
+  font-size: 0.8rem;
+  color: var(--vp-c-text-3);
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.release-list-item .release-meta .release-badge {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.5rem;
+}
+
+.release-list-item .release-excerpt {
+  color: var(--vp-c-text-2);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
 /* ========== Divider ========== */
 .home-section-divider {
   max-width: 1392px;

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -9,204 +9,50 @@ What's new in every release of nav0 Browser.
 
 ---
 
-<div class="release-note" id="v0.0.6">
-  <div class="release-header-row">
+<div class="release-list-item">
+  <a href="/releases/v0.0.6">
     <h2>v0.0.6</h2>
-    <span class="release-badge latest">Latest</span>
-  </div>
-  <div class="release-date-meta">March 3, 2026</div>
-
-  <h3>Ad Blocker</h3>
-  <ul>
-    <li>Comprehensive ad blocker with domain blocking, URL pattern matching, and cosmetic filtering</li>
-    <li>Video ad blocking with IMA SDK mock, play() hook, and early script injection</li>
-    <li>Content-aware video detection and broader CSS selectors</li>
-  </ul>
-
-  <h3>Downloads</h3>
-  <ul>
-    <li>Pause, resume, and cancel downloads</li>
-    <li>Cross-session download resume — paused downloads survive browser restarts</li>
-    <li>Download progress bar with click-to-open</li>
-    <li>Downloads icon with circular progress indicator in the navbar</li>
-  </ul>
-
-  <h3>New Features</h3>
-  <ul>
-    <li><strong>Find in Page</strong> — search any page with Ctrl+F / Cmd+F</li>
-    <li><strong>Reader Mode</strong> — distraction-free reading powered by Readability.js</li>
-    <li><strong>PDF Reader</strong> — open PDFs inline in tabs, plus File &gt; Open PDF (Ctrl+Shift+O)</li>
-    <li><strong>Browser Settings &amp; Preferences Engine</strong> — full settings UI with enforcement</li>
-    <li><strong>Site Permission Handling</strong> — granular permission system with custom in-browser UI</li>
-    <li><strong>Geolocation</strong> — IP-based geolocation fallback for Linux, injected via preload</li>
-  </ul>
-
-  <h3>Improvements</h3>
-  <ul>
-    <li>Updated all icons and logos to new nav0 compass design</li>
-    <li>Blog entries are now dynamic on homepage and sidebar</li>
-    <li>Fixed styling flash (FOUC) on internal pages</li>
-    <li>Disabled Chromium mDNS features that trigger macOS local network dialog</li>
-    <li>Fixed Command+K overlay focus, escape key, and icon spacing</li>
-  </ul>
+  </a>
+  <div class="release-meta">March 3, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Ad blocker, download manager with pause/resume, Find in Page, Reader Mode, PDF Reader, browser settings engine, and site permissions.</p>
 </div>
 
-<div class="release-note" id="v0.0.5-alpha">
-  <div class="release-header-row">
+<div class="release-list-item">
+  <a href="/releases/v0.0.5-alpha">
     <h2>v0.0.5-alpha</h2>
-    <span class="release-badge alpha">Alpha</span>
-  </div>
-  <div class="release-date-meta">March 1, 2026</div>
-
-  <h3>Redesign</h3>
-  <ul>
-    <li>New nav0 compass logo and rebrand from green to Vercel Black theme</li>
-    <li>White background with rounded corners on logo SVGs and icons</li>
-    <li>New dark/light mode hero images for the website</li>
-    <li>Restyled "A complete package" section to match node-llama-cpp design</li>
-  </ul>
-
-  <h3>Bug Fixes</h3>
-  <ul>
-    <li>Fixed Escape key exiting fullscreen across the browser app</li>
-    <li>Fixed hero image aspect ratio appearing flattened</li>
-    <li>Fixed dark mode blank page by removing unused HeroImage component</li>
-    <li>Fixed CSS flash of unstyled content (FOUC) when opening Command+K overlay</li>
-    <li>Fixed crash when toggling Command+K overlay multiple times</li>
-    <li>Fixed dark mode hero gradient invisible on dark background</li>
-    <li>Fixed hero image overflowing viewport on desktop</li>
-  </ul>
-
-  <h3>Improvements</h3>
-  <ul>
-    <li>Launch nav0 automatically after macOS install script completes</li>
-    <li>Added .nojekyll file to prevent Jekyll processing on GitHub Pages</li>
-  </ul>
+  </a>
+  <div class="release-meta">March 1, 2026 <span class="release-badge alpha">Alpha</span></div>
+  <p class="release-excerpt">New nav0 compass logo and Vercel Black rebrand. Multiple bug fixes for fullscreen, hero images, dark mode, and Command+K overlay.</p>
 </div>
 
-<div class="release-note" id="v0.0.4">
-  <div class="release-header-row">
+<div class="release-list-item">
+  <a href="/releases/v0.0.4">
     <h2>v0.0.4</h2>
-  </div>
-  <div class="release-date-meta">March 1, 2026</div>
-
-  <h3>New Content</h3>
-  <ul>
-    <li>New blog post: "The Enshittification of Chrome"</li>
-  </ul>
-
-  <h3>macOS Installation</h3>
-  <ul>
-    <li>Curl install script as the primary macOS install method</li>
-    <li>Install script bypasses Gatekeeper quarantine</li>
-    <li>Falls back to ~/Desktop when /Applications is not writable</li>
-  </ul>
-
-  <h3>Bug Fixes</h3>
-  <ul>
-    <li>Fixed VitePress ESM build error by adding type:module to docs</li>
-    <li>Fixed a crash on startup</li>
-  </ul>
+  </a>
+  <div class="release-meta">March 1, 2026</div>
+  <p class="release-excerpt">macOS curl install script, Gatekeeper bypass, and VitePress ESM build fix.</p>
 </div>
 
-<div class="release-note" id="v0.0.3-alpha">
-  <div class="release-header-row">
+<div class="release-list-item">
+  <a href="/releases/v0.0.3-alpha">
     <h2>v0.0.3-alpha</h2>
-    <span class="release-badge alpha">Alpha</span>
-  </div>
-  <div class="release-date-meta">February 25, 2026</div>
-
-  <h3>Build &amp; Release</h3>
-  <ul>
-    <li>Sync package.json version with release input before building</li>
-  </ul>
+  </a>
+  <div class="release-meta">February 25, 2026 <span class="release-badge alpha">Alpha</span></div>
+  <p class="release-excerpt">Sync package.json version with release input before building.</p>
 </div>
 
-<div class="release-note" id="v0.0.2-alpha">
-  <div class="release-header-row">
+<div class="release-list-item">
+  <a href="/releases/v0.0.2-alpha">
     <h2>v0.0.2-alpha</h2>
-    <span class="release-badge alpha">Alpha</span>
-  </div>
-  <div class="release-date-meta">February 25, 2026</div>
-
-  <h3>Bug Fixes</h3>
-  <ul>
-    <li>Fixed release tag mismatch causing Homebrew update to fail</li>
-  </ul>
+  </a>
+  <div class="release-meta">February 25, 2026 <span class="release-badge alpha">Alpha</span></div>
+  <p class="release-excerpt">macOS stability fixes, Homebrew Cask distribution, downloads page with GitHub Releases integration, and hardened build pipeline.</p>
 </div>
 
-<div class="release-note" id="v0.0.2-alpha-initial">
-  <div class="release-header-row">
-    <h2>0.0.2-alpha</h2>
-    <span class="release-badge alpha">Alpha</span>
-  </div>
-  <div class="release-date-meta">February 24, 2026</div>
-
-  <h3>macOS Stability</h3>
-  <ul>
-    <li>Fixed macOS crash caused by invalid code signature after Electron fuse flipping</li>
-    <li>Removed macOS code signing and notarization from build process</li>
-    <li>Switched macOS distribution to Homebrew Cask</li>
-  </ul>
-
-  <h3>Downloads &amp; Distribution</h3>
-  <ul>
-    <li>Downloads page with live GitHub Releases integration</li>
-    <li>Direct download links for Windows and Linux on install page</li>
-    <li>Hardened build pipeline: fixed injection, upgraded action, dropped nupkg</li>
-    <li>Fixed artifact deletion by adding actions:write permission</li>
-  </ul>
-
-  <h3>New Content</h3>
-  <ul>
-    <li>Blog post: "Why Your Browser Wants You to Sign In"</li>
-    <li>Blog post: "Browser Extensions Won't Save Your Privacy"</li>
-  </ul>
-</div>
-
-<div class="release-note" id="v0.0.1-alpha">
-  <div class="release-header-row">
-    <h2>0.0.1-alpha</h2>
-    <span class="release-badge alpha">Alpha</span>
-  </div>
-  <div class="release-date-meta">February 12, 2026</div>
-
-  <p class="release-intro">The first alpha release of nav0 Browser — a minimal, privacy-focused web browser built on Electron.</p>
-
-  <h3>Core Browser</h3>
-  <ul>
-    <li>Electron-based browser with Chromium engine</li>
-    <li>All AI features removed — clean, minimal browsing experience</li>
-    <li>Tab management, local bookmarks, and download manager</li>
-    <li>History capture with debounce and duplicate prevention</li>
-    <li>Process sandboxing for security</li>
-  </ul>
-
-  <h3>Command-K Search</h3>
-  <ul>
-    <li>Unified search across bookmarks, history, downloads, and the web</li>
-    <li>Open tab search with switch-to-tab action</li>
-    <li>Keyboard navigation with Escape and Tab support</li>
-  </ul>
-
-  <h3>Pagination</h3>
-  <ul>
-    <li>Infinite scroll pagination and compact layout for history, downloads, and bookmarks</li>
-  </ul>
-
-  <h3>Build &amp; Platform</h3>
-  <ul>
-    <li>Electron build for Windows, macOS, and Linux</li>
-    <li>Fixed macOS x64 cross-compile for DMG native modules</li>
-    <li>Fixed Windows build with electron-winstaller install script</li>
-    <li>GitHub Actions workflow for CI/CD</li>
-  </ul>
-
-  <h3>Website</h3>
-  <ul>
-    <li>VitePress documentation site at nav0.org</li>
-    <li>Hero image, blog section, and feature capsules on homepage</li>
-    <li>SEO improvements and LLM-friendly metadata</li>
-    <li>Seven launch blog posts covering privacy, security, and the open web</li>
-  </ul>
+<div class="release-list-item">
+  <a href="/releases/v0.0.1-alpha">
+    <h2>v0.0.1-alpha</h2>
+  </a>
+  <div class="release-meta">February 12, 2026 <span class="release-badge alpha">Alpha</span></div>
+  <p class="release-excerpt">First alpha release — Electron-based browser with Chromium engine, Command-K search, tab management, bookmarks, and VitePress documentation site.</p>
 </div>

--- a/docs/releases/v0.0.1-alpha.md
+++ b/docs/releases/v0.0.1-alpha.md
@@ -1,0 +1,45 @@
+---
+title: "v0.0.1-alpha"
+date: 2026-02-12
+badge: Alpha
+---
+
+# v0.0.1-alpha
+
+<span class="release-badge alpha">Alpha</span>
+
+<div class="release-date-meta">February 12, 2026</div>
+
+The first alpha release of nav0 Browser — a minimal, privacy-focused web browser built on Electron.
+
+## Core Browser
+
+- Electron-based browser with Chromium engine
+- All AI features removed — clean, minimal browsing experience
+- Tab management, local bookmarks, and download manager
+- History capture with debounce and duplicate prevention
+- Process sandboxing for security
+
+## Command-K Search
+
+- Unified search across bookmarks, history, downloads, and the web
+- Open tab search with switch-to-tab action
+- Keyboard navigation with Escape and Tab support
+
+## Pagination
+
+- Infinite scroll pagination and compact layout for history, downloads, and bookmarks
+
+## Build & Platform
+
+- Electron build for Windows, macOS, and Linux
+- Fixed macOS x64 cross-compile for DMG native modules
+- Fixed Windows build with electron-winstaller install script
+- GitHub Actions workflow for CI/CD
+
+## Website
+
+- VitePress documentation site at nav0.org
+- Hero image, blog section, and feature capsules on homepage
+- SEO improvements and LLM-friendly metadata
+- Seven launch blog posts covering privacy, security, and the open web

--- a/docs/releases/v0.0.2-alpha.md
+++ b/docs/releases/v0.0.2-alpha.md
@@ -1,0 +1,33 @@
+---
+title: "v0.0.2-alpha"
+date: 2026-02-25
+badge: Alpha
+---
+
+# v0.0.2-alpha
+
+<span class="release-badge alpha">Alpha</span>
+
+<div class="release-date-meta">February 25, 2026</div>
+
+## Bug Fixes
+
+- Fixed release tag mismatch causing Homebrew update to fail
+
+## macOS Stability
+
+- Fixed macOS crash caused by invalid code signature after Electron fuse flipping
+- Removed macOS code signing and notarization from build process
+- Switched macOS distribution to Homebrew Cask
+
+## Downloads & Distribution
+
+- Downloads page with live GitHub Releases integration
+- Direct download links for Windows and Linux on install page
+- Hardened build pipeline: fixed injection, upgraded action, dropped nupkg
+- Fixed artifact deletion by adding actions:write permission
+
+## New Content
+
+- Blog post: "Why Your Browser Wants You to Sign In"
+- Blog post: "Browser Extensions Won't Save Your Privacy"

--- a/docs/releases/v0.0.3-alpha.md
+++ b/docs/releases/v0.0.3-alpha.md
@@ -1,0 +1,15 @@
+---
+title: "v0.0.3-alpha"
+date: 2026-02-25
+badge: Alpha
+---
+
+# v0.0.3-alpha
+
+<span class="release-badge alpha">Alpha</span>
+
+<div class="release-date-meta">February 25, 2026</div>
+
+## Build & Release
+
+- Sync package.json version with release input before building

--- a/docs/releases/v0.0.4.md
+++ b/docs/releases/v0.0.4.md
@@ -1,0 +1,23 @@
+---
+title: "v0.0.4"
+date: 2026-03-01
+---
+
+# v0.0.4
+
+<div class="release-date-meta">March 1, 2026</div>
+
+## New Content
+
+- New blog post: "The Enshittification of Chrome"
+
+## macOS Installation
+
+- Curl install script as the primary macOS install method
+- Install script bypasses Gatekeeper quarantine
+- Falls back to ~/Desktop when /Applications is not writable
+
+## Bug Fixes
+
+- Fixed VitePress ESM build error by adding type:module to docs
+- Fixed a crash on startup

--- a/docs/releases/v0.0.5-alpha.md
+++ b/docs/releases/v0.0.5-alpha.md
@@ -1,0 +1,33 @@
+---
+title: "v0.0.5-alpha"
+date: 2026-03-01
+badge: Alpha
+---
+
+# v0.0.5-alpha
+
+<span class="release-badge alpha">Alpha</span>
+
+<div class="release-date-meta">March 1, 2026</div>
+
+## Redesign
+
+- New nav0 compass logo and rebrand from green to Vercel Black theme
+- White background with rounded corners on logo SVGs and icons
+- New dark/light mode hero images for the website
+- Restyled "A complete package" section to match node-llama-cpp design
+
+## Bug Fixes
+
+- Fixed Escape key exiting fullscreen across the browser app
+- Fixed hero image aspect ratio appearing flattened
+- Fixed dark mode blank page by removing unused HeroImage component
+- Fixed CSS flash of unstyled content (FOUC) when opening Command+K overlay
+- Fixed crash when toggling Command+K overlay multiple times
+- Fixed dark mode hero gradient invisible on dark background
+- Fixed hero image overflowing viewport on desktop
+
+## Improvements
+
+- Launch nav0 automatically after macOS install script completes
+- Added .nojekyll file to prevent Jekyll processing on GitHub Pages

--- a/docs/releases/v0.0.6.md
+++ b/docs/releases/v0.0.6.md
@@ -1,0 +1,41 @@
+---
+title: "v0.0.6"
+date: 2026-03-03
+badge: Latest
+---
+
+# v0.0.6
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">March 3, 2026</div>
+
+## Ad Blocker
+
+- Comprehensive ad blocker with domain blocking, URL pattern matching, and cosmetic filtering
+- Video ad blocking with IMA SDK mock, play() hook, and early script injection
+- Content-aware video detection and broader CSS selectors
+
+## Downloads
+
+- Pause, resume, and cancel downloads
+- Cross-session download resume — paused downloads survive browser restarts
+- Download progress bar with click-to-open
+- Downloads icon with circular progress indicator in the navbar
+
+## New Features
+
+- **Find in Page** — search any page with Ctrl+F / Cmd+F
+- **Reader Mode** — distraction-free reading powered by Readability.js
+- **PDF Reader** — open PDFs inline in tabs, plus File > Open PDF (Ctrl+Shift+O)
+- **Browser Settings & Preferences Engine** — full settings UI with enforcement
+- **Site Permission Handling** — granular permission system with custom in-browser UI
+- **Geolocation** — IP-based geolocation fallback for Linux, injected via preload
+
+## Improvements
+
+- Updated all icons and logos to new nav0 compass design
+- Blog entries are now dynamic on homepage and sidebar
+- Fixed styling flash (FOUC) on internal pages
+- Disabled Chromium mDNS features that trigger macOS local network dialog
+- Fixed Command+K overlay focus, escape key, and icon spacing


### PR DESCRIPTION
## Summary
Refactored the release notes structure from a single monolithic index page into individual release pages, improving maintainability and user experience. The release sidebar is now dynamically generated from individual markdown files.

## Key Changes

- **Converted release notes to individual pages**: Created separate markdown files for each release (v0.0.1-alpha through v0.0.6) in `/docs/releases/`, each with frontmatter containing title, date, and badge information
- **Simplified index page**: Transformed `/docs/releases/index.md` from a 200+ line document with full release details into a clean list view with excerpts and links to individual release pages
- **Dynamic sidebar generation**: Implemented `getReleaseSidebar()` function in `.vitepress/config.ts` that:
  - Reads all release markdown files from the releases directory
  - Extracts title and date from frontmatter
  - Automatically sorts releases by date (newest first)
  - Generates sidebar navigation items without manual configuration
- **Updated styling**: Added new CSS rules in `custom.css` for the release list layout:
  - `.release-list-item` for individual release entries
  - `.release-meta` for date and badge display
  - `.release-excerpt` for summary text
  - Hover effects and responsive spacing

## Implementation Details

- Each release page maintains the full detailed content (features, bug fixes, improvements) while the index page shows concise excerpts
- Release pages are linked from the index via `/releases/{version}` URLs
- The sidebar automatically stays in sync with available releases without manual updates
- Frontmatter parsing extracts metadata for dynamic sidebar generation and sorting

https://claude.ai/code/session_01Dq6N6QMFRAUWLDycQkkCcd