### PR TITLE
Improve focus management for search bar and tab switching

### DIFF
--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -172,6 +172,7 @@ export class AppWindow {
       const yOffset = 85;
       this.getActiveTab().getWebContentsViewInstance()?.setBounds({x: parentBounds.x, y: yOffset, width: parentBounds.width, height: parentBounds.height - yOffset});
       this.browserWindowInstance.contentView.addChildView(this.getActiveTab().getWebContentsViewInstance());
+      this.getActiveTab().getWebContentsViewInstance().webContents.focus();
     }
     this.browserWindowInstance?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_ACTIVATED, {
       id: this.getActiveTab().id,

--- a/src/renderer/pages/new-tab/index.ts
+++ b/src/renderer/pages/new-tab/index.ts
@@ -16,4 +16,9 @@ if (searchBar) {
       window.BrowserAPI.navigate(window.BrowserAPI.appWindowId, window.BrowserAPI.tabId, query);
     }
   });
+
+  // Re-focus search bar when the page gains focus (e.g. tab switched back to new tab)
+  window.addEventListener('focus', () => {
+    searchBar.focus();
+  });
 }


### PR DESCRIPTION
## Summary
This PR improves the focus management in the browser by ensuring the search bar is refocused when the new tab page regains focus, and by properly focusing the web contents when switching between tabs.

## Key Changes
- **New Tab Page**: Added a window focus event listener that automatically refocuses the search bar when the new tab page regains focus (e.g., when switching back to the new tab from another tab)
- **Tab Switching**: Added explicit focus call to the active tab's web contents when it's activated, ensuring proper focus state when switching between tabs

## Implementation Details
- The search bar focus is restored via a `window.addEventListener('focus')` handler in the new tab page renderer
- Tab activation now calls `webContents.focus()` on the newly active tab's web contents view to ensure keyboard input is properly directed

https://claude.ai/code/session_01QiGDGzBqhJaXwrteu82mT2