### PR TITLE
Release v0.0.7: Dark mode, closed tabs restoration, and stability fixes

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,10 +10,18 @@ What's new in every release of nav0 Browser.
 ---
 
 <div class="release-list-item">
+  <a href="/releases/v0.0.7">
+    <h2>v0.0.7</h2>
+  </a>
+  <div class="release-meta">March 7, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Dark mode toggle for any website, recently closed tabs with full window restoration, stability fixes for tab/window lifecycle crashes, and navbar FOUC resolution.</p>
+</div>
+
+<div class="release-list-item">
   <a href="/releases/v0.0.6">
     <h2>v0.0.6</h2>
   </a>
-  <div class="release-meta">March 3, 2026 <span class="release-badge latest">Latest</span></div>
+  <div class="release-meta">March 3, 2026</div>
   <p class="release-excerpt">Ad blocker, download manager with pause/resume, Find in Page, Reader Mode, PDF Reader, browser settings engine, and site permissions.</p>
 </div>
 

--- a/docs/releases/v0.0.6.md
+++ b/docs/releases/v0.0.6.md
@@ -1,12 +1,9 @@
 ---
 title: "v0.0.6"
 date: 2026-03-03
-badge: Latest
 ---
 
 # v0.0.6
-
-<span class="release-badge latest">Latest</span>
 
 <div class="release-date-meta">March 3, 2026</div>
 

--- a/docs/releases/v0.0.7.md
+++ b/docs/releases/v0.0.7.md
@@ -1,0 +1,38 @@
+---
+title: "v0.0.7"
+date: 2026-03-07
+badge: Latest
+---
+
+# v0.0.7
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">March 7, 2026</div>
+
+## Dark Mode
+
+- Dark mode toggle in the browser navbar — apply dark CSS to any website
+- Improved dark mode coverage for sites like LinkedIn and Reddit
+- Dark mode now persists across back/forward navigation
+
+## Recently Closed Tabs
+
+- **Restore Closed Tabs** — reopen recently closed tabs from the History menu
+- Recently closed tabs are shared across all non-private windows
+- Closed window restoration — reopen an entire window with all its tabs
+- Tabs are now recorded to the closed list when a window is closed via the native close button
+
+## Stability
+
+- Fixed crash caused by navigation debounce timer firing after tab close
+- Fixed null window crash in history recording debounce timer
+- Added null guards for window lookups in tab and window managers
+- WebContents listeners are now removed before closing a tab, preventing use-after-free errors
+- Fixed restored windows closing immediately due to zero-tab auto-close race condition
+
+## UI Improvements
+
+- Fully resolved navbar flash of unstyled content (FOUC) — CSS is now extracted into files and loaded in `<head>`, with window show deferred until content is ready
+- Fixed address bar icon vertical alignment
+- Search bar in new tab page is now auto-focused when a tab is activated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav0-browser",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
This PR documents and releases v0.0.7 of nav0 Browser, introducing dark mode functionality, recently closed tabs restoration, critical stability fixes, and UI improvements.

## Key Changes
- **New Release Documentation**: Added comprehensive v0.0.7 release notes documenting all features and fixes
- **Dark Mode Feature**: Dark mode toggle in navbar with improved coverage for LinkedIn and Reddit; persists across navigation
- **Recently Closed Tabs**: Ability to restore recently closed tabs and entire windows from History menu; shared across non-private windows
- **Stability Improvements**: Fixed multiple crashes including navigation debounce timer firing after tab close, null window crashes, and use-after-free errors in WebContents listeners
- **UI Polish**: Resolved navbar flash of unstyled content (FOUC) by extracting CSS into files and deferring window show; fixed address bar icon alignment; auto-focus search bar in new tab page
- **Version Bump**: Updated package.json version from 0.0.4 to 0.0.7
- **Release Index Update**: Updated releases index to mark v0.0.7 as latest and removed latest badge from v0.0.6

## Notable Implementation Details
- CSS extraction and `<head>` loading strategy eliminates FOUC by ensuring styles are ready before window display
- Closed tabs are recorded when windows close via native close button, enabling full window restoration
- Added null guards throughout tab and window managers to prevent crashes from race conditions
- WebContents listeners are properly cleaned up before tab closure to prevent use-after-free errors

https://claude.ai/code/session_01CZoPttMRGiXEH6xCi5n5Nt