### PR TITLE
Add "Move to Another Window" context menu for tabs

### DIFF
--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -602,37 +602,52 @@ export abstract class AppWindowManager {
           (w) => w.id !== window.id && !w.isPrivate
         );
 
+        const moveSubmenu: Electron.MenuItemConstructorOptions[] = [
+          {
+            label: 'New Window',
+            click: async () => {
+              const url = tab.getUrl();
+              const closedRecord = window.closeTab(tabId, true);
+              if (closedRecord) {
+                AppWindowManager.recordClosedTab(closedRecord);
+              }
+              const newWindow = AppWindowManager.createWindow();
+              await newWindow.whenReady();
+              // Navigate the default tab to the moved tab's URL
+              const defaultTabs = newWindow.getTabs();
+              if (defaultTabs.length > 0) {
+                defaultTabs[0].navigate(url);
+              }
+              AppWindowManager.activateWindow(newWindow.id);
+            },
+          },
+        ];
+
         if (otherWindows.length > 0) {
-          const moveSubmenu: Electron.MenuItemConstructorOptions[] = otherWindows.map((targetWindow, index) => {
+          moveSubmenu.push({ type: 'separator' });
+          for (let index = 0; index < otherWindows.length; index++) {
+            const targetWindow = otherWindows[index];
             const activeTab = targetWindow.getActiveTab();
             const label = activeTab ? activeTab.getTitle() || `Window ${index + 1}` : `Window ${index + 1}`;
-            return {
+            moveSubmenu.push({
               label,
               click: async () => {
                 const url = tab.getUrl();
-                // Close the tab in the source window
                 const closedRecord = window.closeTab(tabId, true);
                 if (closedRecord) {
                   AppWindowManager.recordClosedTab(closedRecord);
                 }
-                // Create the tab in the target window and activate it
                 await targetWindow.createTab(url, true);
-                // Focus the target window
                 AppWindowManager.activateWindow(targetWindow.id);
               },
-            };
-          });
-
-          template.splice(-2, 0, {
-            label: 'Move to Another Window',
-            submenu: moveSubmenu,
-          });
-        } else {
-          template.splice(-2, 0, {
-            label: 'Move to Another Window',
-            enabled: false,
-          });
+            });
+          }
         }
+
+        template.splice(-2, 0, {
+          label: 'Move to Another Window',
+          submenu: moveSubmenu,
+        });
       }
 
       const menu = Menu.buildFromTemplate(template);


### PR DESCRIPTION
## Summary
Added a new "Move to Another Window" context menu option for tabs in non-private windows, allowing users to move tabs to existing windows or create a new window for the tab.

## Key Changes
- Added a new submenu in the tab context menu (only visible for non-private windows) with options to:
  - Move tab to a new window
  - Move tab to any existing non-private window
- The submenu displays existing windows by their active tab title or a generic "Window N" label
- When moving a tab, the original tab is closed and recorded in the closed tabs history
- The target window is automatically activated after the tab is moved

## Implementation Details
- The feature is disabled for private windows to maintain privacy boundaries
- Only non-private windows are shown as move targets
- The moved tab's URL is preserved when creating it in the target window
- Uses `closeTab(tabId, true)` to properly close the original tab and record it for undo functionality
- Automatically focuses the target window after the move operation completes

https://claude.ai/code/session_01BJQCvwQmCHtVu3tCQwpGNy