### PR TITLE
Track active window on focus event

### DIFF
--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -66,6 +66,9 @@ export abstract class AppWindowManager {
     // Record tabs when the native window close event fires (OS close button, Alt+F4, etc.)
     const browserWindow = window.getBrowserWindowInstance();
     if (browserWindow) {
+      browserWindow.on('focus', () => {
+        AppWindowManager.setActiveWindowId(window.id);
+      });
       browserWindow.on('close', () => {
         AppWindowManager.recordWindowTabs(window);
         // Clear pending timers on all tabs to prevent callbacks after window removal


### PR DESCRIPTION
## Summary
Added tracking of the active window when a browser window receives focus, ensuring the active window ID is properly maintained as users switch between windows.

## Key Changes
- Added a `focus` event listener to the browser window that calls `AppWindowManager.setActiveWindowId()` when the window gains focus
- This listener is registered alongside the existing `close` event listener during window initialization

## Implementation Details
The focus event handler is placed before the close event handler in the window setup sequence, ensuring that window focus changes are tracked in real-time as users interact with different application windows. This allows the application to maintain an accurate record of which window is currently active.

https://claude.ai/code/session_017gbCEP7SkorPSua4qKHDLc