### PR TITLE
Add disclaimer page and menu links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -215,7 +215,8 @@ export default defineConfig({
           items: [
             { text: 'Privacy', link: '/guide/privacy' },
             { text: 'Philosophy', link: '/guide/philosophy' },
-            { text: 'Terms of Use', link: '/guide/terms-of-use' }
+            { text: 'Terms of Use', link: '/guide/terms-of-use' },
+            { text: 'Disclaimer', link: '/guide/disclaimer' }
           ]
         },
         {

--- a/docs/guide/disclaimer.md
+++ b/docs/guide/disclaimer.md
@@ -1,0 +1,167 @@
+---
+title: "nav0 Browser Disclaimer — Important Legal Information"
+description: "Read the full disclaimer for nav0 Browser. Understand the terms of use, limitations, and legal notices for this open-source, privacy-focused web browser."
+---
+
+# Disclaimer
+
+This disclaimer governs your use of the nav0 Browser software and the nav0 website. By downloading, installing, or using nav0, you acknowledge that you have read, understood, and agree to the terms outlined below.
+
+## Nature of the Software
+
+### Open-Source Software Provided "As Is"
+
+nav0 Browser is free, open-source software distributed under the **MIT License**. It is provided **"as is"** and **"as available"**, without warranties of any kind, whether express, implied, or statutory. This includes, but is not limited to, implied warranties of merchantability, fitness for a particular purpose, title, and non-infringement.
+
+### Community-Driven Project
+
+nav0 is developed and maintained by volunteer contributors. It is not backed by a corporation, does not generate revenue, and does not operate as a commercial product. The contributors dedicate their time and effort to this project voluntarily, and no contributor is obligated to provide support, updates, patches, or fixes on any timeline or at all.
+
+### Not a Security Product
+
+While nav0 is designed with privacy as a core principle—collecting zero telemetry, zero user data, and making zero unsolicited network requests—it is **not marketed or intended as a security product**. nav0 does not claim to make you immune to all online threats, surveillance, or cyberattacks. No browser can guarantee complete security on the internet.
+
+## Limitation of Liability
+
+### No Liability for Damages
+
+To the fullest extent permitted by applicable law, the nav0 contributors, maintainers, and affiliates shall **not be liable** for any direct, indirect, incidental, special, consequential, or exemplary damages arising out of or in connection with:
+
+- Your use of, or inability to use, nav0 Browser
+- Any content accessed, downloaded, or interacted with through nav0
+- Unauthorized access to or alteration of your data or transmissions
+- Any bugs, viruses, or other harmful components that may be transmitted through websites you visit
+- Loss of data, profits, goodwill, or other intangible losses
+- Any interruption, suspension, or termination of the software or its availability
+
+This limitation applies regardless of the legal theory under which damages are sought, including contract, tort (including negligence), strict liability, or any other basis, even if the contributors have been advised of the possibility of such damages.
+
+### Your Sole Responsibility
+
+You assume **full responsibility** for your use of nav0 Browser. This includes, but is not limited to:
+
+- The websites you choose to visit and the content you access
+- Files you download and execute on your system
+- Extensions or modifications you install
+- Any data you enter into websites while using nav0
+- Compliance with applicable laws in your jurisdiction
+
+## Privacy Disclaimer
+
+### What nav0 Does and Does Not Control
+
+nav0 Browser itself collects **no user data whatsoever**. However, this does not mean your browsing activity is invisible to all parties:
+
+- **Websites you visit** can still collect data about you through cookies, JavaScript, server logs, fingerprinting techniques, and other tracking mechanisms. nav0 provides tools to mitigate some of these (such as tracker blocking and cookie controls), but cannot eliminate all forms of website-level tracking.
+- **Your Internet Service Provider (ISP)** can see your network traffic, including the domains you visit, unless you use additional tools such as a VPN or Tor.
+- **Your network administrator** (employer, school, public Wi-Fi provider) may monitor your internet activity at the network level, which is outside the browser's control.
+- **Search engines** you use through nav0 are third-party services with their own privacy policies and data collection practices. nav0 recommends privacy-respecting search engines such as DuckDuckGo, Startpage, or Brave Search, but the choice is yours.
+- **DNS providers** can see your DNS queries unless you configure DNS-over-HTTPS or another encrypted DNS solution.
+
+### Extensions and Third-Party Code
+
+nav0 supports browser extensions. Any extension you install operates with its own permissions, code, and potentially its own data collection practices. The nav0 project is **not responsible** for the behavior of third-party extensions. We strongly recommend:
+
+- Only installing extensions from trusted sources
+- Reviewing the permissions each extension requests
+- Preferring open-source extensions whose code can be audited
+- Keeping installed extensions to a minimum
+
+## Software Disclaimer
+
+### Built on Chromium and Electron
+
+nav0 is built on top of the **Electron** framework, which embeds the **Chromium** rendering engine. While nav0 configures and hardens these components for privacy, the underlying Chromium and Electron codebases are developed by third parties (Google and the Electron community, respectively). nav0 inherits both the capabilities and any potential vulnerabilities of these upstream projects.
+
+- **Security vulnerabilities** discovered in Chromium or Electron may affect nav0 until patches are applied. nav0 aims to stay current with upstream security releases, but there may be delays.
+- **Rendering behavior** is determined by Chromium. How websites appear and function in nav0 is largely governed by the Chromium engine.
+- **Web standards support** follows Chromium's implementation. nav0 does not independently implement web standards.
+
+### No Guarantee of Availability or Continuity
+
+nav0 is a volunteer-driven open-source project. There is no guarantee that:
+
+- The project will continue to be maintained indefinitely
+- Updates will be released on any particular schedule
+- Specific features will be added, retained, or remain unchanged
+- The project website or download servers will remain available at all times
+- Backward compatibility will be preserved across versions
+
+The open-source nature of nav0 means that even if the original project is discontinued, the community is free to fork and continue development under the terms of the MIT License.
+
+### System Requirements and Compatibility
+
+nav0 is provided for **macOS, Windows, and Linux**. However:
+
+- Not all operating system versions are guaranteed to be supported
+- Performance may vary depending on your hardware and system configuration
+- Certain websites or web applications may not function as expected due to differences in browser behavior, missing features, or site-specific compatibility issues
+- nav0 does not guarantee compatibility with all websites, web applications, or web standards
+
+## Content Disclaimer
+
+### Third-Party Content
+
+nav0 Browser is a tool for accessing the World Wide Web. The content you view, download, or interact with through nav0 is created and hosted by third parties. nav0:
+
+- Does **not** host, control, curate, endorse, or take responsibility for any third-party content
+- Does **not** filter content beyond its built-in ad and tracker blocking capabilities
+- Does **not** verify the accuracy, legality, or safety of content on any website
+- Cannot prevent you from encountering harmful, offensive, misleading, or illegal content online
+
+You are solely responsible for evaluating the content you access and for complying with all applicable laws regarding that content.
+
+### Downloads and Files
+
+Files downloaded through nav0 are sourced from third-party servers. nav0:
+
+- Does **not** scan downloads for malware (beyond basic Chromium-level protections)
+- Does **not** guarantee the safety of any downloaded file
+- Is **not** responsible for any damage caused by files you choose to download and execute
+
+Always exercise caution when downloading files from the internet. Verify the source and consider scanning files with dedicated antivirus software.
+
+## Legal Disclaimer
+
+### Compliance with Laws
+
+nav0 Browser is designed as a general-purpose web browsing tool. It is your responsibility to ensure that your use of nav0 complies with all applicable local, state, national, and international laws and regulations. The nav0 project does not encourage, condone, or support the use of this software for any unlawful purpose.
+
+### Jurisdictional Variations
+
+This disclaimer is intended to be as broadly applicable as possible. However, certain provisions may not be enforceable in all jurisdictions. If any provision of this disclaimer is found to be unenforceable under applicable law, that provision shall be modified to the minimum extent necessary to make it enforceable, and the remaining provisions shall continue in full force and effect.
+
+### No Legal Advice
+
+Nothing in this disclaimer, the nav0 website, the nav0 documentation, or the nav0 source code constitutes legal advice. If you have legal questions about your use of nav0 or your online activities, consult a qualified legal professional in your jurisdiction.
+
+## Intellectual Property
+
+### MIT License
+
+nav0 Browser is released under the [MIT License](https://opensource.org/licenses/MIT). You are free to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, subject to the conditions of the MIT License. The full license text is included with the software and available in the project repository.
+
+### Trademarks
+
+The nav0 name, logo, and associated branding are trademarks of the nav0 project. Use of these trademarks must comply with standard trademark usage guidelines. The open-source license grants rights to the software code, not to the nav0 trademarks.
+
+### Third-Party Intellectual Property
+
+nav0 incorporates third-party open-source software, each governed by its own license. A full list of third-party dependencies and their licenses can be found in the project repository. nav0 respects the intellectual property rights of others and expects its users to do the same.
+
+## Updates to This Disclaimer
+
+This disclaimer may be updated from time to time to reflect changes in the software, legal requirements, or project practices. Significant changes will be communicated through the project's release notes or website. Continued use of nav0 after changes to this disclaimer constitutes acceptance of the updated terms.
+
+Because nav0 is open source, all changes to this disclaimer are tracked in the project's version control history and can be reviewed by anyone.
+
+## Contact
+
+If you have questions or concerns about this disclaimer, you may:
+
+- Open an issue on the [nav0 GitHub repository](https://github.com/nav0-org/nav0-browser)
+- Engage with the community through the project's discussion channels
+
+---
+
+**In summary**: nav0 is a free, open-source browser built by volunteers who believe in privacy and simplicity. We do our best to build a trustworthy tool, but we provide it without warranties. You use it at your own risk, and you are responsible for your own online activities. The internet is a vast and sometimes dangerous place—no browser, including nav0, can change that fundamental reality.

--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -1,4 +1,4 @@
-import { app, dialog, Menu } from "electron";
+import { app, dialog, Menu, shell } from "electron";
 import { AppConstants, InAppUrls } from "../../constants/app-constants";
 import { AppWindowManager } from "./app-window-manager";
 
@@ -146,6 +146,14 @@ export abstract class AppMenuManager {
           {label: 'About Nav0 Browser', click: () => { app.showAboutPanel(); }},
           {label: 'nav0 Philosophy', click: async () => { await AppWindowManager.getActiveWindow().createTab('https://nav0.org/guide/philosophy', true); }},
           {label: 'Terms of Use', click: async() => { await AppWindowManager.getActiveWindow().createTab('https://nav0.org/guide/terms-of-use', true); }},
+          {label: 'Disclaimer', click: async () => {
+            const activeWindow = AppWindowManager.getActiveWindow();
+            if (activeWindow) {
+              await activeWindow.createTab('https://nav0.org/guide/disclaimer', true);
+            } else {
+              await shell.openExternal('https://nav0.org/guide/disclaimer');
+            }
+          }},
         ]
       }
     ];

--- a/src/renderer/options-menu/index.html
+++ b/src/renderer/options-menu/index.html
@@ -110,6 +110,10 @@
             <i data-lucide="file-text" width="16" height="16"></i>
             <span class="dropdown-item-text">Terms of Use</span>
           </div>
+          <div class="dropdown-item" id="disclaimer-option">
+            <i data-lucide="scroll-text" width="16" height="16"></i>
+            <span class="dropdown-item-text">Disclaimer</span>
+          </div>
         </div>
       </div>
       

--- a/src/renderer/options-menu/options-menu-manager.ts
+++ b/src/renderer/options-menu/options-menu-manager.ts
@@ -188,6 +188,11 @@ export class OptionsMenuManager {
       await window.BrowserAPI.hideOptionsMenu(this.appWindowId);
     });
 
+    this.optionsElement?.querySelector('#disclaimer-option')?.addEventListener('click', async () => {
+      await window.BrowserAPI.createTab(this.appWindowId, 'https://nav0.org/guide/disclaimer', true);
+      await window.BrowserAPI.hideOptionsMenu(this.appWindowId);
+    });
+
   }
   public toggleOptionsVisibility(): void {
     this.optionsElement?.classList.toggle('show');


### PR DESCRIPTION
## Summary
This PR adds a comprehensive disclaimer page to the nav0 Browser documentation and integrates links to it throughout the application's user interface.

## Key Changes
- **New disclaimer documentation** (`docs/guide/disclaimer.md`): Added a detailed 167-line disclaimer covering legal information, limitations of liability, privacy practices, software disclaimers, content disclaimers, and intellectual property rights
- **Main menu integration**: Added "Disclaimer" menu item in the Help menu that opens the disclaimer page in a new tab or external browser
- **Options menu integration**: Added "Disclaimer" option in the renderer options menu with a scroll-text icon
- **Documentation navigation**: Updated VitePress config to include the disclaimer link in the "Core Principles" section of the guide sidebar

## Implementation Details
- The disclaimer menu item uses the existing `AppWindowManager.createTab()` pattern for consistency with other menu actions
- Falls back to `shell.openExternal()` if no active window exists
- The options menu handler follows the same pattern as the existing "About" option
- The disclaimer is accessible from both the main application menu and the in-app options dropdown
- Documentation is properly integrated into the VitePress navigation structure with appropriate metadata

https://claude.ai/code/session_01MGSSU4JEvdKxq8e4JRJ46m