### PR TITLE
Add tab pinning functionality to browser

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -162,6 +162,8 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly CLEAR_ALL_PERMISSIONS = "browser:clear-all-permissions";
   public static readonly PERMISSION_PROMPT_READY = "browser:permission-prompt-ready";
   public static readonly SHOW_TAB_CONTEXT_MENU = "browser:show-tab-context-menu";
+  public static readonly PIN_TAB = "browser:pin-tab";
+  public static readonly UNPIN_TAB = "browser:unpin-tab";
 }
 
 export abstract class MainToRendererEventsForBrowserIPC {
@@ -182,6 +184,8 @@ export abstract class MainToRendererEventsForBrowserIPC {
   public static readonly FIND_IN_PAGE_RESULT = "browser:find-in-page-result";
   public static readonly SHOW_PERMISSION_PROMPT = "browser:show-permission-prompt";
   public static readonly HIDE_PERMISSION_PROMPT = "browser:hide-permission-prompt";
+  public static readonly TAB_PINNED = "browser:tab-pinned";
+  public static readonly TAB_UNPINNED = "browser:tab-unpinned";
 }
 
 export abstract class DataStoreConstants {

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -1,4 +1,4 @@
-import { ClosedTabRecord, ClosedWindowRecord, RendererToMainEventsForBrowserIPC, DataStoreConstants } from "../../constants/app-constants";
+import { ClosedTabRecord, ClosedWindowRecord, RendererToMainEventsForBrowserIPC, MainToRendererEventsForBrowserIPC, DataStoreConstants } from "../../constants/app-constants";
 import { AppMenuManager } from "./app-menu-manager";
 import { AppWindow } from "./app-window";
 import { app, dialog, ipcMain, Menu } from "electron";
@@ -542,7 +542,7 @@ export abstract class AppWindowManager {
       return { ok: true };
     });
 
-    ipcMain.on(RendererToMainEventsForBrowserIPC.SHOW_TAB_CONTEXT_MENU, async (event, appWindowId: string, tabId: string) => {
+    ipcMain.on(RendererToMainEventsForBrowserIPC.SHOW_TAB_CONTEXT_MENU, async (event, appWindowId: string, tabId: string, isPinned: boolean) => {
       const window = appWindowId ? AppWindowManager.getWindowById(appWindowId) : AppWindowManager.getActiveWindow();
       if (!window) return;
       const tab = window.getTabById(tabId);
@@ -552,6 +552,17 @@ export abstract class AppWindowManager {
       const isMuted = webContents.isAudioMuted();
 
       const template: Electron.MenuItemConstructorOptions[] = [
+        {
+          label: isPinned ? 'Unpin Tab' : 'Pin Tab',
+          click: () => {
+            if (isPinned) {
+              window.getBrowserWindowInstance()?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_UNPINNED, { id: tabId });
+            } else {
+              window.getBrowserWindowInstance()?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_PINNED, { id: tabId });
+            }
+          },
+        },
+        { type: 'separator' },
         {
           label: 'Reload Tab',
           click: () => {

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -141,8 +141,8 @@ export function init(){
     createNewPrivateAppWindow: async () => {
       return ipcRenderer.send(RendererToMainEventsForBrowserIPC.CREATE_NEW_PRIVATE_APP_WINDOW, {});
     },
-    showTabContextMenu: (appWindowId: string, tabId: string) => {
-      ipcRenderer.send(RendererToMainEventsForBrowserIPC.SHOW_TAB_CONTEXT_MENU, appWindowId, tabId);
+    showTabContextMenu: (appWindowId: string, tabId: string, isPinned: boolean) => {
+      ipcRenderer.send(RendererToMainEventsForBrowserIPC.SHOW_TAB_CONTEXT_MENU, appWindowId, tabId, isPinned);
     },
     showAboutPanel: async () => {
       return ipcRenderer.send(RendererToMainEventsForBrowserIPC.SHOW_ABOUT_PANEL);
@@ -232,6 +232,12 @@ export function init(){
     },
     onFindInPageResult: (callback: (data: { activeMatchOrdinal: number, matches: number, finalUpdate: boolean }) => void) => {
       ipcRenderer.on(MainToRendererEventsForBrowserIPC.FIND_IN_PAGE_RESULT, (_event, data) => callback(data));
+    },
+    onTabPinned: (callback: (data: { id: string }) => void) => {
+      ipcRenderer.on(MainToRendererEventsForBrowserIPC.TAB_PINNED, (_event, data) => callback(data));
+    },
+    onTabUnpinned: (callback: (data: { id: string }) => void) => {
+      ipcRenderer.on(MainToRendererEventsForBrowserIPC.TAB_UNPINNED, (_event, data) => callback(data));
     },
 
     // Permission system

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -251,6 +251,24 @@ export class BrowserTabManager {
       }
     });
 
+    // Tab pinned
+    window.BrowserAPI.onTabPinned((data: { id: string }) => {
+      const tab = this.getTabById(data.id);
+      if (tab) {
+        tab.pinTab();
+        this.reorderPinnedTabs();
+      }
+    });
+
+    // Tab unpinned
+    window.BrowserAPI.onTabUnpinned((data: { id: string }) => {
+      const tab = this.getTabById(data.id);
+      if (tab) {
+        tab.unpinTab();
+        this.reorderPinnedTabs();
+      }
+    });
+
     // Reader mode state changed
     window.BrowserAPI.onReaderModeStateChanged((data: { id: string, isActive: boolean }) => {
       const tab = this.getTabById(data.id);
@@ -393,6 +411,20 @@ export class BrowserTabManager {
 
     this.tabScrollLeftButton.classList.toggle('visible', canScrollLeft);
     this.tabScrollRightButton.classList.toggle('visible', canScrollRight);
+  }
+
+  private reorderPinnedTabs(): void {
+    const pinnedTabs = this.tabs.filter(t => t.isPinned);
+    const unpinnedTabs = this.tabs.filter(t => !t.isPinned);
+    this.tabs = [...pinnedTabs, ...unpinnedTabs];
+
+    // Reorder DOM elements
+    for (const tab of this.tabs) {
+      const el = tab.getTabElement();
+      if (el) {
+        this.tabsContainer.appendChild(el);
+      }
+    }
   }
 
   private scrollActiveTabIntoView(): void {

--- a/src/renderer/browser-layout/index.css
+++ b/src/renderer/browser-layout/index.css
@@ -105,6 +105,19 @@ body.is-private .private-window-identifier{
   opacity: 1;
 }
 
+.tab.pinned {
+  min-width: 36px;
+  width: 36px;
+  max-width: 36px;
+  justify-content: center;
+  padding: 6px 0;
+}
+
+.tab.pinned .tab-favicon {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .tab:hover {
   background-color: var(--bg-hover);
 }

--- a/src/renderer/browser-layout/tab.ts
+++ b/src/renderer/browser-layout/tab.ts
@@ -15,6 +15,7 @@ export class Tab {
   public bookmarkId: string | null = null;
   public isReaderModeEligible = false;
   public isReaderModeActive = false;
+  public isPinned = false;
 
   constructor(id: string, url: string, title?: string) {
     this.id = id;
@@ -54,7 +55,7 @@ export class Tab {
     this.tabElement.addEventListener('contextmenu', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      window.BrowserAPI.showTabContextMenu(appWindowId, this.id);
+      window.BrowserAPI.showTabContextMenu(appWindowId, this.id, this.isPinned);
     });
 
     setTimeout(() => {
@@ -105,6 +106,28 @@ export class Tab {
   deactivateTab(): void {
     if (this.tabElement) {
       this.tabElement.classList.remove('active');
+    }
+  }
+
+  pinTab(): void {
+    this.isPinned = true;
+    if (this.tabElement) {
+      this.tabElement.classList.add('pinned');
+      const titleSpan = this.tabElement.querySelector('#tab-title') as HTMLElement;
+      if (titleSpan) titleSpan.style.display = 'none';
+      const closeButton = this.tabElement.querySelector('#tab-close-button') as HTMLElement;
+      if (closeButton) closeButton.style.display = 'none';
+    }
+  }
+
+  unpinTab(): void {
+    this.isPinned = false;
+    if (this.tabElement) {
+      this.tabElement.classList.remove('pinned');
+      const titleSpan = this.tabElement.querySelector('#tab-title') as HTMLElement;
+      if (titleSpan) titleSpan.style.display = '';
+      const closeButton = this.tabElement.querySelector('#tab-close-button') as HTMLElement;
+      if (closeButton) closeButton.style.display = '';
     }
   }
 

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -58,7 +58,7 @@ declare global {
       findInPageNext: (appWindowId: string, text: string, options?: { matchCase?: boolean }) => Promise<any>;
       findInPagePrevious: (appWindowId: string, text: string, options?: { matchCase?: boolean }) => Promise<any>;
       stopFindInPage: (appWindowId: string) => Promise<any>;
-      showTabContextMenu: (appWindowId: string, tabId: string) => void;
+      showTabContextMenu: (appWindowId: string, tabId: string, isPinned: boolean) => void;
       showAboutPanel: () => Promise<any>;
       getSearchUrl: (searchTerm: string) => Promise<string>;
       fetchOpenTabs: (appWindowId: string) => Promise<Array<{id: string, title: string, url: string, faviconUrl: string | null}>>;
@@ -86,6 +86,8 @@ declare global {
       onReaderModeAvailabilityChanged: (callback: (data: { id: string, isEligible: boolean }) => void) => void;
       onReaderModeStateChanged: (callback: (data: { id: string, isActive: boolean }) => void) => void;
       onFindInPageResult: (callback: (data: { activeMatchOrdinal: number, matches: number, finalUpdate: boolean }) => void) => void;
+      onTabPinned: (callback: (data: { id: string }) => void) => void;
+      onTabUnpinned: (callback: (data: { id: string }) => void) => void;
     };
   }
 }


### PR DESCRIPTION
## Summary
This PR implements tab pinning functionality, allowing users to pin/unpin tabs which are then displayed in a compact form at the beginning of the tab bar.

## Key Changes
- **Tab pinning state management**: Added `isPinned` property to the `Tab` class with `pinTab()` and `unpinTab()` methods that toggle the pinned state and update the UI accordingly
- **Tab reordering**: Implemented `reorderPinnedTabs()` method in `BrowserTabManager` to maintain pinned tabs at the start of the tab list and reorder DOM elements
- **IPC event handlers**: Added `onTabPinned` and `onTabUnpinned` event listeners in the renderer to handle pinning/unpinning operations
- **Context menu integration**: Updated tab context menu to include "Pin Tab"/"Unpin Tab" option that toggles based on current pinned state
- **UI styling**: Added CSS rules for `.tab.pinned` class to display pinned tabs in a compact 36px width with centered favicon and hidden title/close button
- **API updates**: Extended `showTabContextMenu` API to pass `isPinned` state and added new IPC event constants for tab pinning operations

## Implementation Details
- Pinned tabs are visually distinguished with a fixed width of 36px and centered favicon
- Tab title and close button are hidden when a tab is pinned
- Pinned tabs are automatically moved to the beginning of the tab bar when pinned/unpinned
- The pinning state is communicated between main and renderer processes via IPC events

https://claude.ai/code/session_014xXKzjrXrcvxVfXiRT8Tvw