### PR TITLE
Add tooltip support to browser tabs

### DIFF
--- a/src/renderer/browser-layout/tab.ts
+++ b/src/renderer/browser-layout/tab.ts
@@ -35,6 +35,7 @@ export class Tab {
     if (titleSpan) {
       titleSpan.textContent = this.title || 'New Tab';
     }
+    this.tabElement.title = this.title || 'New Tab';
     
     // Add close button event listener
     const closeButton = this.tabElement.querySelector('#tab-close-button');
@@ -69,6 +70,7 @@ export class Tab {
       if (titleSpan) {
         titleSpan.textContent = title || 'New Tab';
       }
+      this.tabElement.title = title || 'New Tab';
     }
   }
 


### PR DESCRIPTION
## Summary
This change adds tooltip support to browser tabs by setting the HTML `title` attribute, which displays the full tab title on hover.

## Key Changes
- Set `tabElement.title` attribute in the tab initialization method to display the tab title as a tooltip
- Set `tabElement.title` attribute in the `setTitle()` method to keep the tooltip in sync when the tab title is updated

## Implementation Details
The tooltip is set to the same value as the displayed tab title (defaulting to "New Tab" if no title is provided). This ensures users can see the full tab title on hover, which is particularly useful when tab titles are truncated due to space constraints in the UI.

https://claude.ai/code/session_01PqqjdFB2YJTsrm6Za3Pzce