### PR TITLE
Pass false flag to createTab for popup and context menu links

### DIFF
--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -334,7 +334,7 @@ export class Tab {
         }
       } else if (disposition === 'foreground-tab' || disposition === 'background-tab'){
         this.popupTimestamps.push(now);
-        this.parentAppWindow.createTab(url);
+        this.parentAppWindow.createTab(url, false);
       } else if (disposition === 'new-window') {
         // Allow popup windows (e.g. OAuth flows like "Continue with Google")
         // to open as real windows, preserving window.opener for callback communication
@@ -885,7 +885,7 @@ export class Tab {
     if (linkURL) { //for clicking on hyperlinks
       template.push(
         { label: 'Open link in new tab', click: () => {
-          parentAppWindow.createTab(linkURL);
+          parentAppWindow.createTab(linkURL, false);
         }},
         { label: 'Open link in new window', click: () => {
           //@todo - implement this


### PR DESCRIPTION
## Summary
Updated two calls to `createTab()` to explicitly pass `false` as the second parameter when opening tabs from popup windows and context menu actions.

## Key Changes
- Modified popup window tab creation (line 337) to pass `false` flag to `createTab()`
- Modified context menu "Open link in new tab" action (line 888) to pass `false` flag to `createTab()`

## Details
Both changes ensure that tabs opened from popup windows and right-click context menu actions are created with the `false` flag. This likely controls whether the new tab should be focused/activated, ensuring these user-initiated tab creations behave consistently with the intended UX behavior.

https://claude.ai/code/session_01UpzJ67FehgDX4fxjrDuswG