### PR TITLE
Add file size display to download items

### DIFF
--- a/src/renderer/common/format-utils.ts
+++ b/src/renderer/common/format-utils.ts
@@ -29,6 +29,14 @@ export abstract class FormatUtils {
     return `${day}-${monthName}-${year.toString().substring(2, 4)}`;
   }
 
+  public static formatFileSize(bytes: number): string {
+    if (bytes <= 0) return '';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const size = bytes / Math.pow(1024, i);
+    return `${size % 1 === 0 ? size : size.toFixed(1)} ${units[i]}`;
+  }
+
   public static getFileMetadata(filePath: string): { fileName: string; fileNameWithoutExtension: string; extension: string } {
     const normalizedPath = filePath.replace(/\\/g, '/');
     const basename = normalizedPath.split('/').pop() || '';

--- a/src/renderer/pages/downloads/index.css
+++ b/src/renderer/pages/downloads/index.css
@@ -70,7 +70,7 @@
 
 .download-item {
   display: grid;
-  grid-template-columns: 140px 24px 1fr auto;
+  grid-template-columns: 140px 24px 1fr auto auto;
   gap: var(--spacing-xs);
   padding: 4px 12px;
   border-bottom: 1px solid var(--border-color);
@@ -123,6 +123,8 @@
 .download-size {
   color: var(--text-secondary);
   font-size: var(--font-xs);
+  white-space: nowrap;
+  text-align: right;
 }
 
 .delete-button {

--- a/src/renderer/pages/downloads/index.ts
+++ b/src/renderer/pages/downloads/index.ts
@@ -206,6 +206,16 @@ const appendDownloadItems = (items: DownloadRecord[]): void => {
         </div>`;
     }
 
+    // Build file size display
+    let sizeHtml = '';
+    if (isActive && activeInfo.totalBytes > 0) {
+      sizeHtml = `<span class="download-size">${FormatUtils.formatFileSize(activeInfo.receivedBytes)} / ${FormatUtils.formatFileSize(activeInfo.totalBytes)}</span>`;
+    } else if (isActive && activeInfo.totalBytes === 0) {
+      sizeHtml = activeInfo.receivedBytes > 0 ? `<span class="download-size">${FormatUtils.formatFileSize(activeInfo.receivedBytes)}</span>` : '';
+    } else if (item.fileSize > 0) {
+      sizeHtml = `<span class="download-size">${FormatUtils.formatFileSize(item.fileSize)}</span>`;
+    }
+
     downloadItem.innerHTML = `
       <div class="download-time">${FormatUtils.getFriendlyDateString(item.createdDate)}</div>
       <div><i data-lucide="${getFileIcon(item.fileExtension)}" class="download-icon"></i></div>
@@ -213,6 +223,7 @@ const appendDownloadItems = (items: DownloadRecord[]): void => {
         <div class="download-filename" title="${item.fileName}">${item.fileName}</div>
         <div class="download-path">${isPausedFromDb ? 'Paused' : item.fileLocation}</div>
       </div>
+      ${sizeHtml}
       <div>
         ${controlsHtml || `<button class="delete-button"><i data-lucide="x" width="14" height="14"></i></button>`}
       </div>
@@ -298,6 +309,16 @@ const updateProgressBar = (fileName: string, receivedBytes: number, totalBytes: 
   }
   const pct = totalBytes > 0 ? Math.round((receivedBytes / totalBytes) * 100) : 0;
   bar.style.width = `${pct}%`;
+
+  // Update file size display
+  const sizeEl = row.querySelector('.download-size') as HTMLElement;
+  if (sizeEl) {
+    if (totalBytes > 0) {
+      sizeEl.textContent = `${FormatUtils.formatFileSize(receivedBytes)} / ${FormatUtils.formatFileSize(totalBytes)}`;
+    } else if (receivedBytes > 0) {
+      sizeEl.textContent = FormatUtils.formatFileSize(receivedBytes);
+    }
+  }
 };
 
 const removeProgressBar = (fileName: string): void => {


### PR DESCRIPTION
## Summary
This PR adds file size information to the downloads list, displaying the current progress and total file size for active downloads, and the total file size for completed downloads.

## Key Changes
- **New utility method**: Added `FormatUtils.formatFileSize()` to convert bytes to human-readable format (B, KB, MB, GB, TB)
- **Download item display**: Modified the download item HTML template to include a new size display element that shows:
  - For active downloads with known total size: "received / total" (e.g., "45.2 MB / 100.5 MB")
  - For active downloads with unknown total size: just the received amount (e.g., "45.2 MB")
  - For completed downloads: the file size from metadata
- **Dynamic updates**: Enhanced `updateProgressBar()` to update the file size display in real-time as downloads progress
- **Layout adjustment**: Updated the download item grid layout from 4 columns to 5 columns to accommodate the new size display element
- **Styling**: Added CSS rules for the size display with right alignment and no-wrap text behavior

## Implementation Details
- The file size display is conditionally rendered based on download state (active vs. completed) and available metadata
- The `formatFileSize()` utility uses logarithmic calculation to determine the appropriate unit and formats decimals to one place when needed
- The size element updates dynamically during active downloads without requiring a full re-render of the download item

https://claude.ai/code/session_01NES55Dbz1PEkYHjr8uyguz