### PR TITLE
Add loading indicator to browser tabs

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -186,6 +186,7 @@ export abstract class MainToRendererEventsForBrowserIPC {
   public static readonly FIND_IN_PAGE_RESULT = "browser:find-in-page-result";
   public static readonly SHOW_PERMISSION_PROMPT = "browser:show-permission-prompt";
   public static readonly HIDE_PERMISSION_PROMPT = "browser:hide-permission-prompt";
+  public static readonly TAB_LOADING_CHANGED = "browser:tab-loading-changed";
   public static readonly TAB_PINNED = "browser:tab-pinned";
   public static readonly TAB_UNPINNED = "browser:tab-unpinned";
 }

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -267,6 +267,20 @@ export class Tab {
 
       await this.handleDownload(item);
     });
+    this.webContentsViewInstance.webContents.on(WebContentsEvents.DID_START_LOADING, () => {
+      if (this._destroyed) return;
+      this.parentAppWindow.getBrowserWindowInstance()?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_LOADING_CHANGED, {
+        id: this.id,
+        isLoading: true
+      });
+    });
+    this.webContentsViewInstance.webContents.on(WebContentsEvents.DID_STOP_LOADING, () => {
+      if (this._destroyed) return;
+      this.parentAppWindow.getBrowserWindowInstance()?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_LOADING_CHANGED, {
+        id: this.id,
+        isLoading: false
+      });
+    });
     this.webContentsViewInstance.webContents.on(WebContentsEvents.PAGE_TITLE_UPDATED, async (event, title: string) => {
       if (this._destroyed) return;
       this.title = title;

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -239,6 +239,9 @@ export function init(){
     onFindInPageResult: (callback: (data: { activeMatchOrdinal: number, matches: number, finalUpdate: boolean }) => void) => {
       ipcRenderer.on(MainToRendererEventsForBrowserIPC.FIND_IN_PAGE_RESULT, (_event, data) => callback(data));
     },
+    onTabLoadingChanged: (callback: (data: { id: string, isLoading: boolean }) => void) => {
+      ipcRenderer.on(MainToRendererEventsForBrowserIPC.TAB_LOADING_CHANGED, (_event, data) => callback(data));
+    },
     onTabPinned: (callback: (data: { id: string }) => void) => {
       ipcRenderer.on(MainToRendererEventsForBrowserIPC.TAB_PINNED, (_event, data) => callback(data));
     },

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -220,6 +220,11 @@ export class BrowserTabManager {
       this.getTabById(data.id)?.updateTabFavicon(data.faviconUrl);
     });
 
+    // Tab loading state changed
+    window.BrowserAPI.onTabLoadingChanged((data: { id: string, isLoading: boolean }) => {
+      this.getTabById(data.id)?.setLoading(data.isLoading);
+    });
+
     // Download progress tracking
     window.BrowserAPI.onDownloadStarted((data: { downloadId: string, fileName: string, totalBytes: number }) => {
       this.activeDownloads.set(data.downloadId, { receivedBytes: 0, totalBytes: data.totalBytes });

--- a/src/renderer/browser-layout/index.css
+++ b/src/renderer/browser-layout/index.css
@@ -138,6 +138,22 @@ body.is-private .private-window-identifier{
   flex-shrink: 0;
 }
 
+.tab-loader {
+  height: 14px;
+  width: 14px;
+  margin-left: 6px;
+  margin-right: 6px;
+  flex-shrink: 0;
+  border: 2px solid var(--border-color, #ccc);
+  border-top-color: var(--primary-color, #666);
+  border-radius: 50%;
+  animation: tab-loader-spin 0.8s linear infinite;
+}
+
+@keyframes tab-loader-spin {
+  to { transform: rotate(360deg); }
+}
+
 .tab-title {
   white-space: nowrap;
   overflow: hidden;

--- a/src/renderer/browser-layout/tab.html
+++ b/src/renderer/browser-layout/tab.html
@@ -1,5 +1,6 @@
 <div class="tab" data-tab-id="">
   <img id="tab-favicon" class="tab-favicon"></img>
+  <div id="tab-loader" class="tab-loader" style="display: none;"></div>
   <span id="tab-title" class="tab-title"></span>
   <button id="tab-close-button" class="tab-close">
     <i data-lucide="x" width="16" height="16"></i>

--- a/src/renderer/browser-layout/tab.ts
+++ b/src/renderer/browser-layout/tab.ts
@@ -86,6 +86,23 @@ export class Tab {
     }
   }
 
+  setLoading(isLoading: boolean): void {
+    this.isLoading = isLoading;
+    if (this.tabElement) {
+      const faviconElement = this.tabElement.querySelector('.tab-favicon') as HTMLElement;
+      const loaderElement = this.tabElement.querySelector('.tab-loader') as HTMLElement;
+      if (faviconElement && loaderElement) {
+        if (isLoading) {
+          faviconElement.style.display = 'none';
+          loaderElement.style.display = 'block';
+        } else {
+          faviconElement.style.display = '';
+          loaderElement.style.display = 'none';
+        }
+      }
+    }
+  }
+
   updateTabFavicon(faviconUrl: string): void {
     if(this.url.startsWith(InAppUrls.PREFIX)) {
       this.faviconUrl = ImageBase64Strings.FAVICON;

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -87,6 +87,7 @@ declare global {
       onReaderModeAvailabilityChanged: (callback: (data: { id: string, isEligible: boolean }) => void) => void;
       onReaderModeStateChanged: (callback: (data: { id: string, isActive: boolean }) => void) => void;
       onFindInPageResult: (callback: (data: { activeMatchOrdinal: number, matches: number, finalUpdate: boolean }) => void) => void;
+      onTabLoadingChanged: (callback: (data: { id: string, isLoading: boolean }) => void) => void;
       onTabPinned: (callback: (data: { id: string }) => void) => void;
       onTabUnpinned: (callback: (data: { id: string }) => void) => void;
     };


### PR DESCRIPTION
## Summary
This PR adds a visual loading indicator to browser tabs that displays while a page is loading. When a tab starts loading, a spinner animation replaces the favicon, and when loading completes, the favicon is restored.

## Key Changes
- **Main Process (src/main/browser/tab.ts)**: Added listeners for `DID_START_LOADING` and `DID_STOP_LOADING` events that emit `TAB_LOADING_CHANGED` IPC messages to the renderer with the tab's loading state
- **Renderer Process (src/renderer/browser-layout/tab.ts)**: Implemented `setLoading()` method that toggles visibility between the favicon and loader elements based on loading state
- **Styling (src/renderer/browser-layout/index.css)**: Added `.tab-loader` styles with a rotating spinner animation (`tab-loader-spin`) that runs continuously during loading
- **UI Template (src/renderer/browser-layout/tab.html)**: Added loader div element next to the favicon in the tab template
- **IPC Communication**: 
  - Added `TAB_LOADING_CHANGED` constant to app constants
  - Registered `onTabLoadingChanged` callback in preload API
  - Added listener in browser manager to handle loading state changes
- **Type Definitions (src/renderer/common/internals-api.ts)**: Updated TypeScript declarations to include the new `onTabLoadingChanged` callback

## Implementation Details
- The loader element uses a CSS-based spinner with a 0.8s rotation animation for smooth visual feedback
- The favicon and loader elements are toggled via `display` CSS property for clean show/hide behavior
- Loading state is tracked at the main process level and communicated to the renderer via IPC, ensuring accurate state synchronization

https://claude.ai/code/session_01AaxmWxmu2stEUNdyMVPEnb