### PR TITLE
Improve CAPTCHA/challenge page handling and bot detection evasion

### DIFF
--- a/src/main/ad-blocker/ad-block-lists.ts
+++ b/src/main/ad-blocker/ad-block-lists.ts
@@ -646,9 +646,18 @@ div[class*="ima-"],
 [id*="clmb"],
 [class*="clmb"],
 
-/* Generic high z-index overlays (ad wrappers) */
-[style*="z-index: 2147483647"],
-[style*="z-index:2147483647"] {
+/* Generic high z-index overlays (ad wrappers) — only target elements with ad-related classes.
+   Avoid hiding legitimate overlays (CAPTCHA, verification challenges, etc.) */
+[style*="z-index: 2147483647"][class*="ad-"],
+[style*="z-index: 2147483647"][class*="ad_"],
+[style*="z-index: 2147483647"][class*="ads-"],
+[style*="z-index: 2147483647"][id*="ad-"],
+[style*="z-index: 2147483647"][id*="ad_"],
+[style*="z-index:2147483647"][class*="ad-"],
+[style*="z-index:2147483647"][class*="ad_"],
+[style*="z-index:2147483647"][class*="ads-"],
+[style*="z-index:2147483647"][id*="ad-"],
+[style*="z-index:2147483647"][id*="ad_"] {
   display: none !important;
   height: 0 !important;
   min-height: 0 !important;
@@ -1272,11 +1281,18 @@ export const AD_BLOCK_SCRIPT = `
           if (rect.width > window.innerWidth * 0.4 && rect.height > window.innerHeight * 0.25) {
             var id = (el.id || '').toLowerCase();
             var cls = (el.className && typeof el.className === 'string') ? el.className.toLowerCase() : '';
-            // Skip legitimate modals
+            // Skip legitimate modals and verification/CAPTCHA overlays
             if (cls.indexOf('cookie') > -1 || cls.indexOf('consent') > -1 ||
                 cls.indexOf('login') > -1 || cls.indexOf('signup') > -1 || cls.indexOf('paywall') > -1 ||
+                cls.indexOf('captcha') > -1 || cls.indexOf('challenge') > -1 ||
+                cls.indexOf('verification') > -1 || cls.indexOf('turnstile') > -1 ||
+                cls.indexOf('hcaptcha') > -1 || cls.indexOf('recaptcha') > -1 ||
+                cls.indexOf('cf-') > -1 || cls.indexOf('awswaf') > -1 ||
                 id.indexOf('cookie') > -1 || id.indexOf('consent') > -1 ||
-                id.indexOf('login') > -1) continue;
+                id.indexOf('login') > -1 ||
+                id.indexOf('captcha') > -1 || id.indexOf('challenge') > -1 ||
+                id.indexOf('verification') > -1 || id.indexOf('turnstile') > -1 ||
+                id.indexOf('cf-') > -1 || id.indexOf('awswaf') > -1) continue;
             hideElement(el);
             // Also remove any backdrop/scrim behind it
             if (el.previousElementSibling) {

--- a/src/main/ad-blocker/ad-block-lists.ts
+++ b/src/main/ad-blocker/ad-block-lists.ts
@@ -1028,6 +1028,25 @@ export const AD_BLOCK_EARLY_SCRIPT = `
 
     return el;
   };
+
+  // ============================================================
+  // 4. Preserve native toString() for overridden functions
+  //    Bot-detection scripts call fn.toString() and check for
+  //    "[native code]". Patch Function.prototype.toString so our
+  //    overrides pass that check.
+  // ============================================================
+  try {
+    var nativeToString = Function.prototype.toString;
+    var toStringOverrides = new Map();
+    toStringOverrides.set(document.createElement, 'function createElement() { [native code] }');
+    toStringOverrides.set(HTMLMediaElement.prototype.play, 'function play() { [native code] }');
+    Function.prototype.toString = function() {
+      if (toStringOverrides.has(this)) return toStringOverrides.get(this);
+      return nativeToString.call(this);
+    };
+    // Hide the toString override itself
+    toStringOverrides.set(Function.prototype.toString, 'function toString() { [native code] }');
+  } catch(e) {}
 })();
 `;
 

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -41,7 +41,6 @@ export class Tab {
   private readerMode: ReaderModeState = ReaderModeManager.createState();
   private readerModeCheckTimer: ReturnType<typeof setTimeout> | null = null;
   private readerModeToggleLock = false;
-  private static pdfSessionsRegistered = new Set<string>();
   private popupTimestamps: number[] = [];
   private static readonly MAX_POPUPS = 3;
   private static readonly POPUP_WINDOW_MS = 60_000;
@@ -164,53 +163,9 @@ export class Tab {
       }
     });
     // User agent is set at the session level by SettingsEnforcer.applyUserAgent()
+    // PDF inline display is handled by SettingsEnforcer.applyCookiePolicy()
     // this.webContentsViewInstance.webContents.openDevTools({mode : 'detach'});
-    this.registerPdfHandler();
     this.initEventHandlers();
-  }
-
-  /**
-   * Registers a session-level handler that forces PDF responses to display inline
-   * instead of triggering a download. Only registers once per session partition.
-   */
-  private registerPdfHandler(): void {
-    if (Tab.pdfSessionsRegistered.has(this.partitionSetting)) return;
-    Tab.pdfSessionsRegistered.add(this.partitionSetting);
-
-    this.webContentsViewInstance.webContents.session.webRequest.onHeadersReceived(
-      (details, callback) => {
-        const headers = details.responseHeaders;
-        if (!headers) {
-          callback({});
-          return;
-        }
-
-        // Find content-type header (case-insensitive)
-        let isPdf = false;
-        for (const key of Object.keys(headers)) {
-          if (key.toLowerCase() === 'content-type') {
-            const value = (headers[key]?.[0] || '').toLowerCase();
-            if (value.includes('application/pdf')) {
-              isPdf = true;
-            }
-            break;
-          }
-        }
-
-        if (isPdf) {
-          // Remove Content-Disposition header to force inline display
-          const newHeaders = { ...headers };
-          for (const key of Object.keys(newHeaders)) {
-            if (key.toLowerCase() === 'content-disposition') {
-              delete newHeaders[key];
-            }
-          }
-          callback({ responseHeaders: newHeaders });
-        } else {
-          callback({ responseHeaders: headers });
-        }
-      }
-    );
   }
 
   private initEventHandlers() {

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -13,6 +13,7 @@ import { PermissionManager } from "./permission-manager";
 import { ReaderModeManager, ReaderModeState } from "./reader-mode-manager";
 import { DataStoreManager } from "../database/data-store-manager";
 import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from "../../types/settings-types";
+import { SettingsEnforcer } from "../settings/settings-enforcer";
 import { COSMETIC_FILTER_CSS, AD_BLOCK_EARLY_SCRIPT, AD_BLOCK_SCRIPT } from "../ad-blocker/ad-block-lists";
 import { SSLManager } from "./ssl-manager";
 import { buildErrorPageScript, NavigationError } from "./error-page/error-page";
@@ -557,6 +558,7 @@ export class Tab {
   private injectAdBlockEarlyScript(url: string): void {
     if (!this.isAdBlockAllowed(url)) return;
     if (Tab.isStreamingSite(url)) return;
+    if (SettingsEnforcer.isChallengePage(this.webContentsViewInstance.webContents.id)) return;
     const wc = this.webContentsViewInstance.webContents;
     wc.executeJavaScript(AD_BLOCK_EARLY_SCRIPT).catch(() => {});
   }
@@ -568,6 +570,7 @@ export class Tab {
   private injectAdBlockDOMScript(): void {
     if (!this.isAdBlockAllowed()) return;
     if (Tab.isStreamingSite(this.url)) return;
+    if (SettingsEnforcer.isChallengePage(this.webContentsViewInstance.webContents.id)) return;
     const wc = this.webContentsViewInstance.webContents;
     wc.insertCSS(COSMETIC_FILTER_CSS).catch(() => {});
     wc.executeJavaScript(AD_BLOCK_SCRIPT).catch(() => {});

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -9,17 +9,6 @@ export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
   private static readonly AUTO_DELETE_CHECK_MS = 6 * 60 * 60 * 1000; // 6 hours
 
-  // Verification / CAPTCHA domains whose cookies must always be allowed as
-  // third-party so that challenge iframes can complete successfully.
-  private static readonly VERIFICATION_COOKIE_DOMAINS: string[] = [
-    'challenges.cloudflare.com',    // Cloudflare Turnstile
-    'cloudflare.com',               // Cloudflare general verification
-    'hcaptcha.com',                 // hCaptcha
-    'google.com',                   // reCAPTCHA
-    'recaptcha.net',                // reCAPTCHA alternate domain
-    'gstatic.com',                  // reCAPTCHA resources
-    'token.awswaf.com',             // AWS WAF Bot Control
-  ];
 
   public static async init() {
     SettingsEnforcer.initIPCHandlers();
@@ -137,14 +126,15 @@ export abstract class SettingsEnforcer {
             if (isThirdParty) {
               const requestDomain = requestUrl.hostname.toLowerCase();
 
-              // Always allow cookies from verification/CAPTCHA domains so
-              // challenge iframes (Turnstile, reCAPTCHA, hCaptcha, etc.) work
-              const isVerificationDomain = SettingsEnforcer.VERIFICATION_COOKIE_DOMAINS.some(d =>
-                requestDomain === d || requestDomain.endsWith('.' + d)
-              );
+              // Check the always-allow list (verification/CAPTCHA domains)
+              const alwaysAllow = (settings.cookieAlwaysAllowDomains || []);
+              const isAlwaysAllowed = alwaysAllow.some(d => {
+                const domain = d.toLowerCase().trim();
+                return requestDomain === domain || requestDomain.endsWith('.' + domain);
+              });
 
-              // Check user-configured exceptions
-              let isExempt = isVerificationDomain;
+              // Check user-configured exceptions (block-with-exceptions mode)
+              let isExempt = isAlwaysAllowed;
               if (!isExempt && settings.cookiePolicy === 'block-with-exceptions') {
                 isExempt = settings.cookieExceptions.some(exception => {
                   const exDomain = exception.toLowerCase().trim();

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -191,12 +191,20 @@ export abstract class SettingsEnforcer {
   ): void {
     if (details.resourceType === 'mainFrame' && details.webContentsId) {
       SettingsEnforcer.challengePageIds.delete(details.webContentsId);
+
+      // Check for cf-mitigated header (set on any Cloudflare challenge, regardless of status code)
+      const cfMitigated = headers['cf-mitigated'] || headers['Cf-Mitigated'] || [];
+      if (cfMitigated.some(v => v.toLowerCase().includes('challenge'))) {
+        SettingsEnforcer.challengePageIds.add(details.webContentsId);
+        return;
+      }
+
+      // Check for Cloudflare challenge responses (403/503 from Cloudflare)
       if (details.statusCode === 403 || details.statusCode === 503) {
         const serverValues = headers['server'] || headers['Server'] || [];
-        const cfMitigated = headers['cf-mitigated'] || headers['Cf-Mitigated'] || [];
-        const isCloudflare = serverValues.some(v => v.toLowerCase().includes('cloudflare'));
-        const isChallengeResponse = cfMitigated.length > 0;
-        if (isCloudflare || isChallengeResponse) {
+        const cfRay = headers['cf-ray'] || headers['Cf-Ray'] || headers['CF-RAY'] || [];
+        const isCloudflare = serverValues.some(v => v.toLowerCase().includes('cloudflare')) || cfRay.length > 0;
+        if (isCloudflare) {
           SettingsEnforcer.challengePageIds.add(details.webContentsId);
         }
       }

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -58,80 +58,121 @@ export abstract class SettingsEnforcer {
     });
   }
 
-  // ---- Cookie Policy Enforcement ----
+  // ---- Cookie Policy & Response Header Enforcement ----
+  // This single onHeadersReceived handler manages both cookie policy
+  // and PDF inline display to avoid conflicting listeners on the same session.
   private static applyCookiePolicy(settings: BrowserSettings) {
-    const ses = session.fromPartition('persist:browsertabs');
-    // Remove existing listeners to prevent duplicates
-    ses.webRequest.onBeforeSendHeaders(null);
-    ses.webRequest.onHeadersReceived(null);
+    const sessions = [
+      session.fromPartition('persist:browsertabs'),
+      session.fromPartition('persist:private'),
+    ];
 
-    if (settings.blockAllCookies) {
-      // Block all cookies
-      ses.webRequest.onBeforeSendHeaders((details, callback) => {
-        const headers = { ...details.requestHeaders };
-        delete headers['Cookie'];
-        callback({ requestHeaders: headers });
-      });
-      ses.webRequest.onHeadersReceived((details, callback) => {
-        const headers = { ...details.responseHeaders };
-        delete headers['set-cookie'];
-        delete headers['Set-Cookie'];
-        callback({ responseHeaders: headers });
-      });
-      return;
-    }
+    for (const ses of sessions) {
+      // Remove existing listeners to prevent duplicates
+      ses.webRequest.onBeforeSendHeaders(null);
+      ses.webRequest.onHeadersReceived(null);
 
-    if (settings.cookiePolicy === 'block-all-third-party' || settings.cookiePolicy === 'block-with-exceptions') {
+      if (settings.blockAllCookies) {
+        // Block all cookies
+        ses.webRequest.onBeforeSendHeaders((details, callback) => {
+          const headers = { ...details.requestHeaders };
+          delete headers['Cookie'];
+          callback({ requestHeaders: headers });
+        });
+        ses.webRequest.onHeadersReceived((details, callback) => {
+          const headers = { ...details.responseHeaders };
+          if (!headers) { callback({}); return; }
+          delete headers['set-cookie'];
+          delete headers['Set-Cookie'];
+          // Also handle PDF inline display
+          SettingsEnforcer.applyPdfInlineHeaders(headers);
+          callback({ responseHeaders: headers });
+        });
+        continue;
+      }
+
+      const blockThirdParty = settings.cookiePolicy === 'block-all-third-party' || settings.cookiePolicy === 'block-with-exceptions';
+
+      // Always register onHeadersReceived so PDF inline display works
+      // regardless of cookie policy setting
       ses.webRequest.onHeadersReceived((details, callback) => {
         if (!details.responseHeaders) {
           callback({});
           return;
         }
 
-        const setCookieHeaders = details.responseHeaders['set-cookie'] || details.responseHeaders['Set-Cookie'];
-        if (!setCookieHeaders) {
-          callback({ responseHeaders: details.responseHeaders });
-          return;
-        }
+        let headers = details.responseHeaders;
 
-        // Determine if this is a third-party request
-        const requestUrl = new URL(details.url);
-        const frameUrl = details.frame?.url || details.referrer || '';
-        let isThirdParty = false;
+        // --- Third-party cookie blocking ---
+        if (blockThirdParty) {
+          const setCookieHeaders = headers['set-cookie'] || headers['Set-Cookie'];
+          if (setCookieHeaders) {
+            const requestUrl = new URL(details.url);
+            const frameUrl = details.frame?.url || details.referrer || '';
+            let isThirdParty = false;
 
-        if (frameUrl) {
-          try {
-            const frameUrlObj = new URL(frameUrl);
-            const requestDomain = SettingsEnforcer.getRegistrableDomain(requestUrl.hostname);
-            const frameDomain = SettingsEnforcer.getRegistrableDomain(frameUrlObj.hostname);
-            isThirdParty = requestDomain !== frameDomain;
-          } catch {
-            // If we can't parse, allow it
-          }
-        }
+            if (frameUrl) {
+              try {
+                const frameUrlObj = new URL(frameUrl);
+                const requestDomain = SettingsEnforcer.getRegistrableDomain(requestUrl.hostname);
+                const frameDomain = SettingsEnforcer.getRegistrableDomain(frameUrlObj.hostname);
+                isThirdParty = requestDomain !== frameDomain;
+              } catch {
+                // If we can't parse, allow it
+              }
+            }
 
-        if (isThirdParty) {
-          // Check exceptions
-          if (settings.cookiePolicy === 'block-with-exceptions') {
-            const requestDomain = requestUrl.hostname.toLowerCase();
-            const isExempt = settings.cookieExceptions.some(exception => {
-              const exDomain = exception.toLowerCase().trim();
-              return requestDomain === exDomain || requestDomain.endsWith('.' + exDomain);
-            });
-            if (isExempt) {
-              callback({ responseHeaders: details.responseHeaders });
-              return;
+            if (isThirdParty) {
+              // Check exceptions
+              let isExempt = false;
+              if (settings.cookiePolicy === 'block-with-exceptions') {
+                const requestDomain = requestUrl.hostname.toLowerCase();
+                isExempt = settings.cookieExceptions.some(exception => {
+                  const exDomain = exception.toLowerCase().trim();
+                  return requestDomain === exDomain || requestDomain.endsWith('.' + exDomain);
+                });
+              }
+
+              if (!isExempt) {
+                headers = { ...headers };
+                delete headers['set-cookie'];
+                delete headers['Set-Cookie'];
+              }
             }
           }
-          // Block third-party cookies
-          const headers = { ...details.responseHeaders };
-          delete headers['set-cookie'];
-          delete headers['Set-Cookie'];
-          callback({ responseHeaders: headers });
-        } else {
-          callback({ responseHeaders: details.responseHeaders });
         }
+
+        // --- PDF inline display ---
+        SettingsEnforcer.applyPdfInlineHeaders(headers);
+
+        callback({ responseHeaders: headers });
       });
+    }
+  }
+
+  /**
+   * Removes Content-Disposition headers from PDF responses so they display
+   * inline in the browser instead of triggering a download.
+   * Mutates the headers object in place.
+   */
+  private static applyPdfInlineHeaders(headers: Record<string, string[]>): void {
+    let isPdf = false;
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'content-type') {
+        const value = (headers[key]?.[0] || '').toLowerCase();
+        if (value.includes('application/pdf')) {
+          isPdf = true;
+        }
+        break;
+      }
+    }
+
+    if (isPdf) {
+      for (const key of Object.keys(headers)) {
+        if (key.toLowerCase() === 'content-disposition') {
+          delete headers[key];
+        }
+      }
     }
   }
 

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -36,6 +36,11 @@ export abstract class SettingsEnforcer {
   }
 
   private static initIPCHandlers() {
+    // Synchronous check used by the preload script to skip polyfill injection
+    // on Cloudflare/CAPTCHA challenge pages.
+    ipcMain.on('is-challenge-page', (event) => {
+      event.returnValue = SettingsEnforcer.isChallengePage(event.sender.id);
+    });
     ipcMain.handle(RendererToMainEventsForBrowserIPC.APPLY_SETTINGS, async () => {
       const settings = SettingsEnforcer.getSettings();
       SettingsEnforcer.applyCookiePolicy(settings);

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -9,6 +9,18 @@ export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
   private static readonly AUTO_DELETE_CHECK_MS = 6 * 60 * 60 * 1000; // 6 hours
 
+  // Verification / CAPTCHA domains whose cookies must always be allowed as
+  // third-party so that challenge iframes can complete successfully.
+  private static readonly VERIFICATION_COOKIE_DOMAINS: string[] = [
+    'challenges.cloudflare.com',    // Cloudflare Turnstile
+    'cloudflare.com',               // Cloudflare general verification
+    'hcaptcha.com',                 // hCaptcha
+    'google.com',                   // reCAPTCHA
+    'recaptcha.net',                // reCAPTCHA alternate domain
+    'gstatic.com',                  // reCAPTCHA resources
+    'token.awswaf.com',             // AWS WAF Bot Control
+  ];
+
   public static async init() {
     SettingsEnforcer.initIPCHandlers();
     const settings = SettingsEnforcer.getSettings();
@@ -123,10 +135,17 @@ export abstract class SettingsEnforcer {
             }
 
             if (isThirdParty) {
-              // Check exceptions
-              let isExempt = false;
-              if (settings.cookiePolicy === 'block-with-exceptions') {
-                const requestDomain = requestUrl.hostname.toLowerCase();
+              const requestDomain = requestUrl.hostname.toLowerCase();
+
+              // Always allow cookies from verification/CAPTCHA domains so
+              // challenge iframes (Turnstile, reCAPTCHA, hCaptcha, etc.) work
+              const isVerificationDomain = SettingsEnforcer.VERIFICATION_COOKIE_DOMAINS.some(d =>
+                requestDomain === d || requestDomain.endsWith('.' + d)
+              );
+
+              // Check user-configured exceptions
+              let isExempt = isVerificationDomain;
+              if (!isExempt && settings.cookiePolicy === 'block-with-exceptions') {
                 isExempt = settings.cookieExceptions.some(exception => {
                   const exDomain = exception.toLowerCase().trim();
                   return requestDomain === exDomain || requestDomain.endsWith('.' + exDomain);

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -9,6 +9,15 @@ export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
   private static readonly AUTO_DELETE_CHECK_MS = 6 * 60 * 60 * 1000; // 6 hours
 
+  // Tracks webContentsIds whose current main-frame navigation is a
+  // Cloudflare/CAPTCHA challenge page. Ad-blocker injection is skipped
+  // for these pages so the verification scripts can run unmodified.
+  private static challengePageIds = new Set<number>();
+
+  /** Returns true if the given webContents is currently on a challenge page. */
+  public static isChallengePage(webContentsId: number): boolean {
+    return SettingsEnforcer.challengePageIds.has(webContentsId);
+  }
 
   public static async init() {
     SettingsEnforcer.initIPCHandlers();
@@ -85,8 +94,8 @@ export abstract class SettingsEnforcer {
           if (!headers) { callback({}); return; }
           delete headers['set-cookie'];
           delete headers['Set-Cookie'];
-          // Also handle PDF inline display
           SettingsEnforcer.applyPdfInlineHeaders(headers);
+          SettingsEnforcer.detectChallengePage(details, headers);
           callback({ responseHeaders: headers });
         });
         continue;
@@ -154,6 +163,9 @@ export abstract class SettingsEnforcer {
         // --- PDF inline display ---
         SettingsEnforcer.applyPdfInlineHeaders(headers);
 
+        // --- Challenge page detection ---
+        SettingsEnforcer.detectChallengePage(details, headers);
+
         callback({ responseHeaders: headers });
       });
     }
@@ -164,6 +176,28 @@ export abstract class SettingsEnforcer {
    * inline in the browser instead of triggering a download.
    * Mutates the headers object in place.
    */
+  /**
+   * Detects Cloudflare/CAPTCHA challenge pages from main-frame responses and
+   * tracks them so the ad-blocker can skip script injection on those pages.
+   */
+  private static detectChallengePage(
+    details: { resourceType?: string; webContentsId?: number; statusCode?: number },
+    headers: Record<string, string[]>
+  ): void {
+    if (details.resourceType === 'mainFrame' && details.webContentsId) {
+      SettingsEnforcer.challengePageIds.delete(details.webContentsId);
+      if (details.statusCode === 403 || details.statusCode === 503) {
+        const serverValues = headers['server'] || headers['Server'] || [];
+        const cfMitigated = headers['cf-mitigated'] || headers['Cf-Mitigated'] || [];
+        const isCloudflare = serverValues.some(v => v.toLowerCase().includes('cloudflare'));
+        const isChallengeResponse = cfMitigated.length > 0;
+        if (isCloudflare || isChallengeResponse) {
+          SettingsEnforcer.challengePageIds.add(details.webContentsId);
+        }
+      }
+    }
+  }
+
   private static applyPdfInlineHeaders(headers: Record<string, string[]>): void {
     let isPdf = false;
     for (const key of Object.keys(headers)) {

--- a/src/preload/web-content-preload.ts
+++ b/src/preload/web-content-preload.ts
@@ -314,10 +314,82 @@ const SHARE_POLYFILL_CODE = `
 })();
 `;
 
+// Browser identity patch: makes navigator.userAgentData report Chrome brands
+// instead of Electron. This is always injected (including on challenge pages)
+// because it corrects a browser identity mismatch, not adds new functionality.
+const BROWSER_IDENTITY_PATCH = `
+(function() {
+  if (window.__Nav0IdentityPatched) return;
+  window.__Nav0IdentityPatched = true;
+
+  // Patch navigator.userAgentData to report Chrome instead of Electron.
+  // Electron includes "Electron" in the brands list, which bot-detection
+  // scripts (Cloudflare Turnstile, etc.) flag as non-standard.
+  try {
+    var ua = navigator.userAgent || '';
+    var chromeMatch = ua.match(/Chrome\\/(\\d+)/);
+    if (chromeMatch && navigator.userAgentData) {
+      var majorVersion = chromeMatch[1];
+      var fakeBrands = [
+        { brand: 'Chromium', version: majorVersion },
+        { brand: 'Google Chrome', version: majorVersion },
+        { brand: 'Not-A.Brand', version: '99' }
+      ];
+      var fakeMobile = navigator.userAgentData.mobile || false;
+      var fakePlatform = navigator.userAgentData.platform || 'Unknown';
+
+      Object.defineProperty(navigator, 'userAgentData', {
+        get: function() {
+          return {
+            brands: fakeBrands,
+            mobile: fakeMobile,
+            platform: fakePlatform,
+            getHighEntropyValues: function(hints) {
+              return Promise.resolve({
+                brands: fakeBrands,
+                mobile: fakeMobile,
+                platform: fakePlatform,
+                uaFullVersion: majorVersion + '.0.0.0',
+                fullVersionList: fakeBrands.map(function(b) { return { brand: b.brand, version: b.version + '.0.0.0' }; }),
+                architecture: 'x86',
+                bitness: '64',
+                model: '',
+                platformVersion: '10.0.0',
+                wow64: false
+              });
+            },
+            toJSON: function() {
+              return { brands: fakeBrands, mobile: fakeMobile, platform: fakePlatform };
+            }
+          };
+        },
+        configurable: true
+      });
+    }
+  } catch(e) {}
+})();
+`;
+
+function injectScript(code: string): void {
+  try {
+    const blob = new Blob([code], { type: 'application/javascript' });
+    const blobUrl = URL.createObjectURL(blob);
+    const script = document.createElement('script');
+    script.src = blobUrl;
+    script.onload = () => { URL.revokeObjectURL(blobUrl); script.remove(); };
+    script.onerror = () => { URL.revokeObjectURL(blobUrl); script.remove(); };
+    (document.head || document.documentElement).appendChild(script);
+  } catch { /* ignore */ }
+}
+
 function injectPolyfill(): void {
   try {
-    // Skip injection on Cloudflare/CAPTCHA challenge pages so Turnstile's
-    // environment integrity checks see an unmodified browser environment.
+    // Always inject browser identity patches (including on challenge pages)
+    // to correct Electron's userAgentData which exposes "Electron" in brands.
+    injectScript(BROWSER_IDENTITY_PATCH);
+
+    // Skip functionality polyfills on Cloudflare/CAPTCHA challenge pages so
+    // Turnstile's environment integrity checks see unmodified native APIs.
     try {
       if (ipcRenderer.sendSync('is-challenge-page')) return;
     } catch { /* ignore — fall through to inject */ }
@@ -334,22 +406,7 @@ function injectPolyfill(): void {
     }
 
     const code = POLYFILL_CODE + SHARE_POLYFILL_CODE + NOTIFICATION_POLYFILL_CODE;
-
-    // Use a blob URL instead of inline script to avoid CSP violations.
-    // Blob URLs are allowed by most CSPs that include 'blob:' in script-src.
-    const blob = new Blob([code], { type: 'application/javascript' });
-    const blobUrl = URL.createObjectURL(blob);
-    const script = document.createElement('script');
-    script.src = blobUrl;
-    script.onload = () => {
-      URL.revokeObjectURL(blobUrl);
-      script.remove();
-    };
-    script.onerror = () => {
-      URL.revokeObjectURL(blobUrl);
-      script.remove();
-    };
-    (document.head || document.documentElement).appendChild(script);
+    injectScript(code);
   } catch {
     // Ignore injection errors
   }

--- a/src/preload/web-content-preload.ts
+++ b/src/preload/web-content-preload.ts
@@ -316,6 +316,12 @@ const SHARE_POLYFILL_CODE = `
 
 function injectPolyfill(): void {
   try {
+    // Skip injection on Cloudflare/CAPTCHA challenge pages so Turnstile's
+    // environment integrity checks see an unmodified browser environment.
+    try {
+      if (ipcRenderer.sendSync('is-challenge-page')) return;
+    } catch { /* ignore — fall through to inject */ }
+
     // Skip injection on pages with strict CSP that blocks inline scripts.
     // Check for a meta CSP tag; server-sent CSP headers can't be read from
     // the preload, but the try/catch below handles that case silently.

--- a/src/preload/web-content-preload.ts
+++ b/src/preload/web-content-preload.ts
@@ -319,8 +319,8 @@ const SHARE_POLYFILL_CODE = `
 // because it corrects a browser identity mismatch, not adds new functionality.
 const BROWSER_IDENTITY_PATCH = `
 (function() {
-  if (window.__Nav0IdentityPatched) return;
-  window.__Nav0IdentityPatched = true;
+  if (window.__nav0IdP) return;
+  window.__nav0IdP = 1;
 
   // Ensure window.chrome exists. Electron does not expose this object,
   // but real Chrome always has it. Its absence is a basic bot detection signal.
@@ -412,7 +412,19 @@ function injectPolyfill(): void {
     // Skip functionality polyfills on Cloudflare/CAPTCHA challenge pages so
     // Turnstile's environment integrity checks see unmodified native APIs.
     try {
-      if (ipcRenderer.sendSync('is-challenge-page')) return;
+      if (ipcRenderer.sendSync('is-challenge-page')) {
+        // Clean up non-standard __Nav0* bridge objects exposed by contextBridge
+        // so Turnstile doesn't see custom properties on window.
+        injectScript(`(function(){
+          var props = ['__Nav0Geo','__Nav0Share','__Nav0Notify','__nav0IdP',
+                       '__Nav0GeolocationPatched','__Nav0NotificationPatched','__Nav0SharePatched'];
+          for (var i = 0; i < props.length; i++) {
+            try { Object.defineProperty(window, props[i], {value:undefined,writable:true,configurable:true}); } catch(e) {}
+            try { delete window[props[i]]; } catch(e) {}
+          }
+        })();`);
+        return;
+      }
     } catch { /* ignore — fall through to inject */ }
 
     // Skip injection on pages with strict CSP that blocks inline scripts.

--- a/src/preload/web-content-preload.ts
+++ b/src/preload/web-content-preload.ts
@@ -322,6 +322,27 @@ const BROWSER_IDENTITY_PATCH = `
   if (window.__Nav0IdentityPatched) return;
   window.__Nav0IdentityPatched = true;
 
+  // Ensure window.chrome exists. Electron does not expose this object,
+  // but real Chrome always has it. Its absence is a basic bot detection signal.
+  try {
+    if (!window.chrome) {
+      window.chrome = {};
+    }
+    if (!window.chrome.runtime) {
+      window.chrome.runtime = {
+        connect: function() { return { onMessage: { addListener: function(){} }, postMessage: function(){}, onDisconnect: { addListener: function(){} } }; },
+        sendMessage: function() {},
+        id: undefined
+      };
+    }
+    if (!window.chrome.csi) {
+      window.chrome.csi = function() { return { startE: Date.now(), onloadT: Date.now(), pageT: Date.now() - performance.timing.navigationStart, tran: 15 }; };
+    }
+    if (!window.chrome.loadTimes) {
+      window.chrome.loadTimes = function() { return { commitLoadTime: Date.now() / 1000, connectionInfo: 'h2', finishDocumentLoadTime: Date.now() / 1000, finishLoadTime: Date.now() / 1000, firstPaintAfterLoadTime: 0, firstPaintTime: Date.now() / 1000, navigationType: 'Other', npnNegotiatedProtocol: 'h2', requestTime: Date.now() / 1000 - 0.1, startLoadTime: Date.now() / 1000 - 0.1, wasAlternateProtocolAvailable: false, wasFetchedViaSpdy: true, wasNpnNegotiated: true }; };
+    }
+  } catch(e) {}
+
   // Patch navigator.userAgentData to report Chrome instead of Electron.
   // Electron includes "Electron" in the brands list, which bot-detection
   // scripts (Cloudflare Turnstile, etc.) flag as non-standard.

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -341,15 +341,20 @@
           <label class="setting-label">User Agent</label>
           <p class="setting-description">Controls how this browser identifies itself to websites. Some sites may serve different content based on the browser identity.</p>
           <select id="user-agent-select" class="form-select">
+            <option value="chrome-windows">Chrome on Windows</option>
+            <option value="chrome-mac">Chrome on macOS</option>
+            <option value="chrome-linux">Chrome on Linux</option>
             <option value="firefox-windows">Firefox on Windows</option>
             <option value="firefox-mac">Firefox on macOS</option>
             <option value="firefox-linux">Firefox on Linux</option>
-            <option value="chrome-windows">Chrome on Windows</option>
-            <option value="chrome-mac">Chrome on macOS</option>
             <option value="safari-mac">Safari on macOS</option>
             <option value="edge-windows">Edge on Windows</option>
             <option value="custom">Custom...</option>
           </select>
+          <div class="alert alert-warning" id="ua-warning" style="display: none; margin-top: 8px;">
+            Choosing a user agent that doesn't match the browser engine (Chromium) may cause websites to break or trigger bot detection on some sites.
+          </div>
+          <button id="ua-restore-default" class="btn btn-secondary" style="display: none; margin-top: 8px;">Restore to default</button>
           <div id="custom-ua-container" class="sub-setting" style="display: none;">
             <label class="setting-label">Custom User Agent String</label>
             <input type="text" id="custom-ua-input" class="form-input" placeholder="Enter your custom user agent string...">

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -96,6 +96,17 @@
             </label>
           </div>
 
+          <!-- Always Allow List -->
+          <div id="cookie-always-allow-container" class="sub-setting" style="display: none;">
+            <label class="setting-label">Always Allow List</label>
+            <p class="setting-description">Cookies from these domains are always allowed, even as third-party. This ensures verification challenges (CAPTCHAs) and login flows work correctly.</p>
+            <div id="cookie-always-allow-list" class="items-list"></div>
+            <div class="add-item-form">
+              <input type="text" id="cookie-always-allow-input" class="form-input" placeholder="e.g., accounts.google.com">
+              <button class="btn btn-sm btn-secondary" id="add-cookie-always-allow-btn"><i data-lucide="plus" width="14" height="14"></i> Add</button>
+            </div>
+          </div>
+
           <!-- Cookie Exceptions -->
           <div id="cookie-exceptions-container" class="sub-setting" style="display: none;">
             <label class="setting-label">Cookie Exceptions</label>

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -232,6 +232,7 @@ function renderCustomEngines() {
 function initCookieSettings() {
   const radios = document.querySelectorAll('input[name="cookie-policy"]') as NodeListOf<HTMLInputElement>;
   const exceptionsContainer = document.getElementById('cookie-exceptions-container');
+  const alwaysAllowContainer = document.getElementById('cookie-always-allow-container');
   const blockAllToggle = document.getElementById('block-all-cookies-toggle') as HTMLInputElement;
   const clearOnCloseToggle = document.getElementById('clear-cookies-close-toggle') as HTMLInputElement;
   const clearCookiesBtn = document.getElementById('clear-cookies-btn');
@@ -241,15 +242,19 @@ function initCookieSettings() {
   blockAllToggle.checked = settings.blockAllCookies || false;
   clearOnCloseToggle.checked = settings.clearCookiesOnClose || false;
 
-  // Show/hide exceptions
-  if (settings.cookiePolicy === 'block-with-exceptions') {
-    exceptionsContainer.style.display = '';
-  }
+  // Show/hide sub-lists based on policy
+  const showCookieSublists = () => {
+    const policy = settings.cookiePolicy;
+    const blocksThirdParty = policy === 'block-all-third-party' || policy === 'block-with-exceptions';
+    alwaysAllowContainer.style.display = blocksThirdParty ? '' : 'none';
+    exceptionsContainer.style.display = policy === 'block-with-exceptions' ? '' : 'none';
+  };
+  showCookieSublists();
 
   radios.forEach(radio => {
     radio.addEventListener('change', () => {
       settings.cookiePolicy = radio.value as BrowserSettings['cookiePolicy'];
-      exceptionsContainer.style.display = radio.value === 'block-with-exceptions' ? '' : 'none';
+      showCookieSublists();
       saveSettings();
       showToast('Cookie policy updated');
     });
@@ -263,6 +268,22 @@ function initCookieSettings() {
   clearOnCloseToggle.addEventListener('change', () => {
     settings.clearCookiesOnClose = clearOnCloseToggle.checked;
     saveSettings();
+  });
+
+  // Always-allow list
+  renderCookieAlwaysAllow();
+
+  document.getElementById('add-cookie-always-allow-btn')?.addEventListener('click', () => {
+    const input = document.getElementById('cookie-always-allow-input') as HTMLInputElement;
+    const domain = input.value.trim();
+    if (!domain) return;
+    if (!settings.cookieAlwaysAllowDomains) settings.cookieAlwaysAllowDomains = [...DEFAULT_BROWSER_SETTINGS.cookieAlwaysAllowDomains];
+    if (settings.cookieAlwaysAllowDomains.indexOf(domain) === -1) {
+      settings.cookieAlwaysAllowDomains.push(domain);
+      saveSettings();
+      input.value = '';
+      renderCookieAlwaysAllow();
+    }
   });
 
   // Cookie exceptions
@@ -310,6 +331,38 @@ async function updateCookieCount() {
       display.textContent = `${result.count} cookies stored.`;
     }
   } catch { /* ignore */ }
+}
+
+function renderCookieAlwaysAllow() {
+  const container = document.getElementById('cookie-always-allow-list');
+  if (!container) return;
+  container.innerHTML = '';
+
+  const defaults = DEFAULT_BROWSER_SETTINGS.cookieAlwaysAllowDomains;
+  const domains = settings.cookieAlwaysAllowDomains || [...defaults];
+
+  domains.forEach((domain, idx) => {
+    const isBuiltIn = defaults.indexOf(domain) !== -1;
+    const item = document.createElement('div');
+    item.className = 'list-item';
+    item.innerHTML = `
+      <div class="list-item-content">
+        <span class="list-item-text">${domain}</span>
+        ${isBuiltIn ? '<span class="list-item-description">Built-in</span>' : ''}
+      </div>
+      <div class="list-item-actions">
+        <button class="list-item-btn" title="Remove"><i data-lucide="x" width="14" height="14"></i></button>
+      </div>
+    `;
+    item.querySelector('.list-item-btn')?.addEventListener('click', () => {
+      settings.cookieAlwaysAllowDomains.splice(idx, 1);
+      saveSettings();
+      renderCookieAlwaysAllow();
+    });
+    container.appendChild(item);
+  });
+
+  createIcons({ icons });
 }
 
 function renderCookieExceptions() {

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -662,18 +662,23 @@ function initUserAgentSettings() {
   const customContainer = document.getElementById('custom-ua-container');
   const customInput = document.getElementById('custom-ua-input') as HTMLInputElement;
   const preview = document.getElementById('ua-preview');
+  const warning = document.getElementById('ua-warning');
+  const restoreBtn = document.getElementById('ua-restore-default') as HTMLButtonElement;
+
+  const defaultPreset = process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows';
 
   // Set initial values
-  const defaultPreset = process.platform === 'darwin' ? 'firefox-mac' : process.platform === 'linux' ? 'firefox-linux' : 'firefox-windows';
   select.value = settings.userAgentPreset || defaultPreset;
   customInput.value = settings.userAgentCustomValue || '';
   customContainer.style.display = select.value === 'custom' ? '' : 'none';
   updateUAPreview();
+  updateUAWarning();
 
   select.addEventListener('change', () => {
     settings.userAgentPreset = select.value as BrowserSettings['userAgentPreset'];
     customContainer.style.display = select.value === 'custom' ? '' : 'none';
     updateUAPreview();
+    updateUAWarning();
     saveSettings();
     showToast('User agent updated');
   });
@@ -685,6 +690,16 @@ function initUserAgentSettings() {
     showToast('Custom user agent saved');
   });
 
+  restoreBtn.addEventListener('click', () => {
+    select.value = defaultPreset;
+    settings.userAgentPreset = defaultPreset as BrowserSettings['userAgentPreset'];
+    customContainer.style.display = 'none';
+    updateUAPreview();
+    updateUAWarning();
+    saveSettings();
+    showToast('User agent restored to default');
+  });
+
   function updateUAPreview() {
     const preset = select.value;
     let ua: string;
@@ -694,6 +709,14 @@ function initUserAgentSettings() {
       ua = USER_AGENT_PRESETS[preset]?.value || navigator.userAgent;
     }
     preview.textContent = `Current: ${ua}`;
+  }
+
+  function updateUAWarning() {
+    const preset = select.value;
+    const isDefault = preset === defaultPreset;
+    const isChromiumCompatible = preset.startsWith('chrome-') || preset === 'edge-windows';
+    warning.style.display = !isChromiumCompatible && preset !== 'custom' ? '' : 'none';
+    restoreBtn.style.display = isDefault ? 'none' : '';
   }
 }
 

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -75,7 +75,7 @@ export interface BrowserSettings {
   popupBlockedSites: string[];
 
   // User Agent
-  userAgentPreset: 'chrome-windows' | 'chrome-mac' | 'safari-mac' | 'firefox-windows' | 'firefox-mac' | 'firefox-linux' | 'edge-windows' | 'custom';
+  userAgentPreset: 'chrome-windows' | 'chrome-mac' | 'chrome-linux' | 'safari-mac' | 'firefox-windows' | 'firefox-mac' | 'firefox-linux' | 'edge-windows' | 'custom';
   userAgentCustomValue: string;
 
   // Keyboard Shortcuts
@@ -170,6 +170,10 @@ export const USER_AGENT_PRESETS: Record<string, { label: string; value: string }
   'chrome-mac': {
     label: 'Chrome on macOS',
     value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+  },
+  'chrome-linux': {
+    label: 'Chrome on Linux',
+    value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
   },
   'safari-mac': {
     label: 'Safari on macOS',
@@ -268,8 +272,9 @@ export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
   popupAllowedSites: [],
   popupBlockedSites: [],
 
-  // User Agent (Firefox UA matching the user's OS by default)
-  userAgentPreset: typeof process !== 'undefined' && process.platform === 'darwin' ? 'firefox-mac' : typeof process !== 'undefined' && process.platform === 'linux' ? 'firefox-linux' : 'firefox-windows',
+  // User Agent (Chrome UA matching the user's OS — must match the actual Chromium
+  // engine to avoid bot-detection fingerprint mismatches)
+  userAgentPreset: typeof process !== 'undefined' && process.platform === 'darwin' ? 'chrome-mac' : typeof process !== 'undefined' && process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows',
   userAgentCustomValue: '',
 
   // Keyboard Shortcuts (empty = use defaults)

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -38,6 +38,7 @@ export interface BrowserSettings {
   // Privacy - Cookies
   cookiePolicy: 'block-all-third-party' | 'block-with-exceptions' | 'allow-all';
   cookieExceptions: string[];
+  cookieAlwaysAllowDomains: string[];
   blockAllCookies: boolean;
   clearCookiesOnClose: boolean;
 
@@ -236,6 +237,15 @@ export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
   // Privacy - Cookies (strict by default)
   cookiePolicy: 'block-all-third-party',
   cookieExceptions: [],
+  cookieAlwaysAllowDomains: [
+    'challenges.cloudflare.com',    // Cloudflare Turnstile
+    'cloudflare.com',               // Cloudflare general verification
+    'hcaptcha.com',                 // hCaptcha
+    'google.com',                   // reCAPTCHA
+    'recaptcha.net',                // reCAPTCHA alternate domain
+    'gstatic.com',                  // reCAPTCHA resources
+    'token.awswaf.com',             // AWS WAF Bot Control
+  ],
   blockAllCookies: false,
   clearCookiesOnClose: false,
 


### PR DESCRIPTION
## Summary
This PR enhances the browser's ability to handle Cloudflare CAPTCHA and verification challenges by detecting challenge pages and skipping ad-blocker injection on them. It also improves bot detection evasion through better browser identity spoofing and adds a whitelist for domains that should always be allowed cookies (for verification flows).

## Key Changes

### Challenge Page Detection & Ad-Blocker Skipping
- Added `challengePageIds` tracking in `SettingsEnforcer` to identify when a webContents is on a Cloudflare/CAPTCHA challenge page
- Implemented `detectChallengePage()` to identify challenges via `cf-mitigated` headers or Cloudflare 403/503 responses
- Added IPC handler `is-challenge-page` for preload script to query challenge status
- Modified ad-blocker injection points (`injectAdBlockEarlyScript`, `injectAdBlockDOMScript`) to skip injection on challenge pages, allowing verification scripts to run unmodified

### Browser Identity & Bot Detection Evasion
- Added `BROWSER_IDENTITY_PATCH` that:
  - Creates `window.chrome` object (absent in Electron, present in real Chrome)
  - Patches `navigator.userAgentData` to report Chrome brands instead of Electron
  - Implements `chrome.runtime`, `chrome.csi`, and `chrome.loadTimes` stubs
- Refactored script injection into reusable `injectScript()` function using blob URLs
- Always inject browser identity patch (even on challenge pages) since it corrects identity mismatch
- Skip functionality polyfills on challenge pages to avoid exposing custom `__Nav0*` bridge objects to Turnstile

### Cookie Policy & Always-Allow List
- Added `cookieAlwaysAllowDomains` setting to whitelist domains that should always receive cookies (e.g., `challenges.cloudflare.com`, `hcaptcha.com`)
- Refactored cookie policy enforcement to handle both regular and private sessions
- Consolidated PDF inline display and challenge detection into single `onHeadersReceived` handler to avoid listener conflicts
- Updated UI to show/hide always-allow list based on cookie policy (visible when blocking third-party cookies)

### Ad-Blocker Refinements
- Restricted high z-index overlay hiding to only target elements with ad-related classes/IDs to avoid hiding legitimate CAPTCHA/verification overlays
- Enhanced modal detection to skip CAPTCHA, challenge, verification, Turnstile, hCaptcha, reCAPTCHA, and Cloudflare WAF elements
- Added `Function.prototype.toString()` override to make overridden functions appear native to bot-detection scripts

### User Agent Improvements
- Added Chrome on Linux preset to user agent options
- Changed default preset from Firefox to Chrome (platform-specific: `chrome-windows`, `chrome-mac`, `chrome-linux`)
- Added warning when non-Chromium user agents are selected (since Chromium-based agents work better with modern sites)
- Added "Restore Default" button to easily reset user agent to platform default

### Code Organization
- Moved PDF inline display handling from `Tab.registerPdfHandler()` to `SettingsEnforcer.applyPdfInlineHeaders()`
- Removed per-session PDF handler registration in favor of centralized enforcement
- Extracted `applyPdfInlineHeaders()` as separate method for clarity

## Notable Implementation Details
- Challenge page detection uses multiple signals: `cf-mitigated` header (most reliable), Cloudflare server header + cf-ray, and status codes 403/503
- Browser identity patch is always injected to correct Electron's userAgentData exposure
- Functionality polyfills are skipped on challenge pages to prevent Turnstile from detecting custom window properties
- Cookie always-allow list includes built-in verification domains by default but allows user customization
- Blob URL injection method used for all scripts to bypass CSP restrictions

https://claude.ai/code/session_017WHUuAWP3ZjxACZDC83vBD