### PR TITLE
Add comprehensive browsing history analytics and session grouping

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -119,6 +119,7 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly REMOVE_BROWSING_HISTORY = "browser:remove-browsing-history";
   public static readonly REMOVE_ALL_BROWSING_HISTORY = "browser:remove-all-browsing-history";
   public static readonly FETCH_BROWSING_HISTORY = "browser:fetch-browsing-history";
+  public static readonly FETCH_BROWSING_HISTORY_STATS = "browser:fetch-browsing-history-stats";
 
   public static readonly HANDLE_FILE_SELECTION = "browser:handle-file-selection";
   public static readonly OPEN_PDF_FILE = "browser:open-pdf-file";

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -280,6 +280,7 @@ export class AppWindow {
           };
         }
       }
+      tab.finalizePageTime();
       tab.clearPendingTimers();
       PermissionManager.clearSessionPermissionsForTab(id);
       // Clean up notifications for this tab's webContents
@@ -321,7 +322,9 @@ export class AppWindow {
     }
 
     if(this.activeTabId && this.getActiveTab()){
-      const prevView = this.getActiveTab().getWebContentsViewInstance();
+      const prevTab = this.getActiveTab();
+      prevTab.pauseActiveTime();
+      const prevView = prevTab.getWebContentsViewInstance();
       if (prevView) {
         this.browserWindowInstance.contentView.removeChildView(prevView);
       }
@@ -335,6 +338,7 @@ export class AppWindow {
         await tab.unsuspend();
       }
       tab.updateLastActivatedAt();
+      tab.resumeActiveTime();
 
       // Restore per-tab strip state for the new tab BEFORE calculating offset
       const findState = this.findInPageState.get(id);

--- a/src/main/browser/browsing-history-manager.ts
+++ b/src/main/browser/browsing-history-manager.ts
@@ -48,7 +48,7 @@ export abstract class BrowsingHistoryManager {
     const stmt = db.prepare("INSERT INTO browsingHistory (id, url, title, createdDate, topLevelDomain, faviconUrl) VALUES (?, ?, ?, ?, ?, ?);");
     const id = uuid();
     const result = await stmt.run(id, url, title, new Date().toISOString(), topLevelDomain, faviconUrl);
-    const newlyCreatedRecord: BrowsingHistoryRecord = { id: id, url, title, createdDate: new Date(), topLevelDomain, faviconUrl };
+    const newlyCreatedRecord: BrowsingHistoryRecord = { id: id, url, title, createdDate: new Date(), topLevelDomain, faviconUrl, totalDuration: 0, activeDuration: 0 };
     return newlyCreatedRecord;
   }
 
@@ -74,7 +74,7 @@ export abstract class BrowsingHistoryManager {
       }
       const id = uuid();
       insertStmt.run(id, url, title, now, topLevelDomain, faviconUrl);
-      return { id, url, title, createdDate: new Date(now), topLevelDomain, faviconUrl } as BrowsingHistoryRecord;
+      return { id, url, title, createdDate: new Date(now), topLevelDomain, faviconUrl, totalDuration: 0, activeDuration: 0 } as BrowsingHistoryRecord;
     });
 
     return upsert(url, title, topLevelDomain, faviconUrl);

--- a/src/main/browser/browsing-history-manager.ts
+++ b/src/main/browser/browsing-history-manager.ts
@@ -18,6 +18,10 @@ export abstract class BrowsingHistoryManager {
       return await BrowsingHistoryManager.fetchRecords(appWindowId, searchTerm, limit, offset);
     });
 
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.FETCH_BROWSING_HISTORY_STATS, async (event, appWindowId: string) => {
+      return await BrowsingHistoryManager.fetchHistoryStats(appWindowId);
+    });
+
     ipcMain.handle(RendererToMainEventsForBrowserIPC.REMOVE_BROWSING_HISTORY, async (event, appWindowId: string, recordId: string) => {
       return await BrowsingHistoryManager.removeRecord(appWindowId, recordId);
     });
@@ -119,5 +123,25 @@ export abstract class BrowsingHistoryManager {
     const stmt = db.prepare("DELETE FROM browsingHistory;");
     await stmt.run();
     return true;
+  }
+
+  public static updateRecordTimeTracking(appWindowId: string, recordId: string, totalDuration: number, activeDuration: number, outTimestamp: string): void {
+    const db = BrowsingHistoryManager.getDb(appWindowId);
+    if (!db) return;
+    const stmt = db.prepare("UPDATE browsingHistory SET totalDuration = ?, activeDuration = ?, outTimestamp = ? WHERE id = ?;");
+    stmt.run(totalDuration, activeDuration, outTimestamp, recordId);
+  }
+
+  public static async fetchHistoryStats(appWindowId: string): Promise<Array<{ date: string; count: number; activeDuration: number }>> {
+    const db = BrowsingHistoryManager.getDb(appWindowId);
+    if (!db) return [];
+    const stmt = db.prepare(`
+      SELECT DATE(createdDate) as date, COUNT(*) as count, COALESCE(SUM(activeDuration), 0) as activeDuration
+      FROM browsingHistory
+      WHERE createdDate >= DATE('now', '-365 days')
+      GROUP BY DATE(createdDate)
+      ORDER BY date ASC;
+    `);
+    return stmt.all() as Array<{ date: string; count: number; activeDuration: number }>;
   }
 }

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -58,7 +58,7 @@ export class Tab {
   private activeTimeAccumulator = 0;
   private lastActiveStart: number | null = null;
   private timeFlushInterval: ReturnType<typeof setInterval> | null = null;
-  private static readonly TIME_FLUSH_INTERVAL_MS = 60_000;
+  private static readonly TIME_FLUSH_INTERVAL_MS = 900_000;
 
   constructor(parentAppWindow: AppWindow, url: string , partitionSetting: string, options?: { suspended?: boolean; title?: string }) {
     this.parentAppWindow = parentAppWindow;

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -57,6 +57,8 @@ export class Tab {
   private pageStartTime: number | null = null;
   private activeTimeAccumulator = 0;
   private lastActiveStart: number | null = null;
+  private timeFlushInterval: ReturnType<typeof setInterval> | null = null;
+  private static readonly TIME_FLUSH_INTERVAL_MS = 60_000;
 
   constructor(parentAppWindow: AppWindow, url: string , partitionSetting: string, options?: { suspended?: boolean; title?: string }) {
     this.parentAppWindow = parentAppWindow;
@@ -760,6 +762,7 @@ export class Tab {
       this.pageStartTime = Date.now();
       this.activeTimeAccumulator = 0;
       this.lastActiveStart = Date.now();
+      this.startTimeFlush();
     } catch (error) {
       // Window may have been closed/removed before the debounced history recording fired
     }
@@ -804,6 +807,7 @@ export class Tab {
 
   clearPendingTimers(): void {
     this._destroyed = true;
+    this.stopTimeFlush();
     if (this.navigationDebounceTimer) {
       clearTimeout(this.navigationDebounceTimer);
       this.navigationDebounceTimer = null;
@@ -845,7 +849,42 @@ export class Tab {
     }
   }
 
+  /**
+   * Persist current time data to the DB without resetting tracking state.
+   * Called periodically so long-running tabs don't lose data on crash.
+   */
+  private flushPageTime(): void {
+    if (!this.lastHistoryRecordId || !this.pageStartTime || !this.parentAppWindow) return;
+    const now = Date.now();
+    const totalDuration = Math.floor((now - this.pageStartTime) / 1000);
+    let activeDuration = this.activeTimeAccumulator;
+    if (this.lastActiveStart) {
+      activeDuration += Math.floor((now - this.lastActiveStart) / 1000);
+    }
+    try {
+      BrowsingHistoryManager.updateRecordTimeTracking(
+        this.parentAppWindow.id, this.lastHistoryRecordId,
+        totalDuration, activeDuration, new Date(now).toISOString()
+      );
+    } catch {
+      // Window may have been closed
+    }
+  }
+
+  private startTimeFlush(): void {
+    this.stopTimeFlush();
+    this.timeFlushInterval = setInterval(() => this.flushPageTime(), Tab.TIME_FLUSH_INTERVAL_MS);
+  }
+
+  private stopTimeFlush(): void {
+    if (this.timeFlushInterval) {
+      clearInterval(this.timeFlushInterval);
+      this.timeFlushInterval = null;
+    }
+  }
+
   finalizePageTime(): void {
+    this.stopTimeFlush();
     if (!this.lastHistoryRecordId || !this.pageStartTime || !this.parentAppWindow) return;
     this.pauseActiveTime();
     const totalDuration = Math.floor((Date.now() - this.pageStartTime) / 1000);

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -54,6 +54,9 @@ export class Tab {
   private pdfDownloadBypass = false;
   private isSuspended = false;
   private lastActivatedAt: Date = new Date();
+  private pageStartTime: number | null = null;
+  private activeTimeAccumulator = 0;
+  private lastActiveStart: number | null = null;
 
   constructor(parentAppWindow: AppWindow, url: string , partitionSetting: string, options?: { suspended?: boolean; title?: string }) {
     this.parentAppWindow = parentAppWindow;
@@ -732,6 +735,8 @@ export class Tab {
       this.lastHistoryRecordId = null;
       return;
     }
+    // Finalize time tracking for the previous page before recording the new one
+    this.finalizePageTime();
     try {
       let urlObject: URL | null = null;
       try {
@@ -751,6 +756,10 @@ export class Tab {
         urlObject ? `${urlObject.protocol}//${urlObject.hostname}/favicon.ico` : ''
       );
       this.lastHistoryRecordId = record?.id ?? null;
+      // Start time tracking for the new page
+      this.pageStartTime = Date.now();
+      this.activeTimeAccumulator = 0;
+      this.lastActiveStart = Date.now();
     } catch (error) {
       // Window may have been closed/removed before the debounced history recording fired
     }
@@ -825,8 +834,32 @@ export class Tab {
     this.lastActivatedAt = new Date();
   }
 
+  resumeActiveTime(): void {
+    this.lastActiveStart = Date.now();
+  }
+
+  pauseActiveTime(): void {
+    if (this.lastActiveStart) {
+      this.activeTimeAccumulator += Math.floor((Date.now() - this.lastActiveStart) / 1000);
+      this.lastActiveStart = null;
+    }
+  }
+
+  finalizePageTime(): void {
+    if (!this.lastHistoryRecordId || !this.pageStartTime || !this.parentAppWindow) return;
+    this.pauseActiveTime();
+    const totalDuration = Math.floor((Date.now() - this.pageStartTime) / 1000);
+    const activeDuration = this.activeTimeAccumulator;
+    const outTimestamp = new Date().toISOString();
+    BrowsingHistoryManager.updateRecordTimeTracking(
+      this.parentAppWindow.id, this.lastHistoryRecordId,
+      totalDuration, activeDuration, outTimestamp
+    );
+  }
+
   suspend(): void {
     if (this.isSuspended || this._destroyed) return;
+    this.finalizePageTime();
     // Clear timers but preserve tab identity (don't set _destroyed permanently)
     if (this.navigationDebounceTimer) {
       clearTimeout(this.navigationDebounceTimer);

--- a/src/main/database/schema/browsing-history-schema.ts
+++ b/src/main/database/schema/browsing-history-schema.ts
@@ -33,6 +33,21 @@ export const BrowsingHistorySchema: TableSchema = {
       name: 'faviconUrl',
       columnType: { type: 'standard', sqlType: 'TEXT' }
       // No notNull constraint since it's optional
+    },
+    {
+      name: 'totalDuration',
+      columnType: { type: 'standard', sqlType: 'INTEGER' },
+      defaultValue: 0
+    },
+    {
+      name: 'activeDuration',
+      columnType: { type: 'standard', sqlType: 'INTEGER' },
+      defaultValue: 0
+    },
+    {
+      name: 'outTimestamp',
+      columnType: { type: 'timestamp' }
+      // Nullable — set when user navigates away or closes tab
     }
   ],
   indices: [

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -96,6 +96,9 @@ export function init(){
     fetchBrowsingHistory: async (appWindowId: string, searchTerm: string, limit: number, offset: number) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.FETCH_BROWSING_HISTORY, appWindowId, searchTerm, limit, offset);
     },
+    fetchBrowsingHistoryStats: async (appWindowId: string) => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.FETCH_BROWSING_HISTORY_STATS, appWindowId);
+    },
     handleFileSelection: async (appWindowId: string, tabId: string, extensions: string[]) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.HANDLE_FILE_SELECTION, appWindowId, tabId, extensions);
     },

--- a/src/renderer/common/format-utils.ts
+++ b/src/renderer/common/format-utils.ts
@@ -37,6 +37,25 @@ export abstract class FormatUtils {
     return `${size % 1 === 0 ? size : size.toFixed(1)} ${units[i]}`;
   }
 
+  public static formatDuration(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+
+  public static getRelativeDayLabel(date: Date): string {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const target = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const diff = Math.floor((today.getTime() - target.getTime()) / 86400000);
+    if (diff === 0) return 'today';
+    if (diff === 1) return 'yesterday';
+    if (diff < 7) return date.toLocaleDateString([], { weekday: 'long' }).toLowerCase();
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' }).toLowerCase();
+  }
+
   public static getFileMetadata(filePath: string): { fileName: string; fileNameWithoutExtension: string; extension: string } {
     const normalizedPath = filePath.replace(/\\/g, '/');
     const basename = normalizedPath.split('/').pop() || '';

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -40,6 +40,7 @@ declare global {
       removeBrowsingHistory: (appWindowId: string, historyId: string) => Promise<any>;
       removeAllBrowsingHistory: (appWindowId: string) => Promise<any>;
       fetchBrowsingHistory: (appWindowId: string, searchTerm: string, limit: number, offset: number) => Promise<any>;
+      fetchBrowsingHistoryStats: (appWindowId: string) => Promise<Array<{ date: string; count: number; activeDuration: number }>>;
       handleFileSelection: (appWindowId: string, tabId: string, extensions: string[]) => Promise<string[] | null>;
       openPdfFile: (appWindowId: string) => Promise<string | null>;
 

--- a/src/renderer/pages/history/index.css
+++ b/src/renderer/pages/history/index.css
@@ -1,158 +1,590 @@
 @import url("../../styles/global.css");
 
-.hero-section {
-  background-color: var(--primary-light);
-  padding: var(--spacing-sm) 0;
-  margin-bottom: var(--spacing-md);
-}
-
-.hero-section h1 {
-  font-size: var(--font-xxl);
-  margin-bottom: 2px;
-}
-
-.hero-section p {
-  font-size: var(--font-sm);
-  margin-bottom: var(--spacing-xs);
-}
-
-.search-container {
-  max-width: 600px;
-  margin: 0 auto var(--spacing-md);
-  position: relative;
-}
-
-.no-history {
-  padding: var(--spacing-md) !important;
-  text-align: center !important;
-  color: var(--text-secondary);
-  font-size: var(--font-sm);
-}
-
-.search-input {
-  width: 100%;
-  padding: 8px var(--spacing-md) 8px 32px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  font-size: var(--font-sm);
-}
-
-.search-input:focus {
-  outline: none;
-  border-color: var(--primary-color);
-}
-
-.search-icon {
-  position: absolute;
-  left: var(--spacing-sm);
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--text-secondary);
+/* Page layout */
+.history-page {
+  min-height: 100vh;
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 .history-container {
-  background-color: var(--bg-light);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-  overflow: hidden;
-}
-
-.history-list {
-  max-height: calc(100vh - 200px);
-  overflow-y: auto;
-}
-
-.history-item {
-  display: grid;
-  grid-template-columns: 140px 20px 1fr 36px;
-  gap: var(--spacing-xs);
-  padding: 4px 12px;
-  border-bottom: 1px solid var(--border-color);
-  align-items: center;
-  cursor: pointer;
-  transition: background-color var(--transition-fast);
-}
-
-.history-item:hover {
-  background-color: var(--bg-hover);
-}
-
-.history-time {
-  color: var(--text-secondary);
-  font-size: var(--font-xs);
-}
-
-.history-favicon {
-  width: 14px;
-  height: 14px;
+  max-width: 960px;
   margin: 0 auto;
+  padding: 32px 24px;
 }
 
-.history-content {
+/* Header */
+.history-header {
   display: flex;
-  flex-direction: column;
-  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.history-header-left {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
 }
 
 .history-title {
-  font-weight: 500;
-  font-size: var(--font-sm);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.3;
+  font-size: var(--font-xl);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0;
 }
 
-.history-domain {
-  color: var(--text-secondary);
+.history-stats-label {
   font-size: var(--font-xs);
-  line-height: 1.2;
+  color: var(--text-secondary);
 }
 
-.delete-button {
-  background-color: transparent;
-  color: var(--text-secondary);
-  border: none;
+.history-header-right {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.btn-delete-selected {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: var(--font-xs);
+  background: var(--error-light);
+  color: var(--error-color);
+  border: 1px solid #fecaca;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  opacity: 0;
-  transition: opacity var(--transition-fast);
+  font-weight: 500;
+}
+
+.btn-clear-all {
+  padding: 4px 10px;
+  font-size: var(--font-xs);
+  background: var(--bg-light);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.btn-clear-all:hover {
+  color: var(--error-color);
+  border-color: var(--error-color);
+}
+
+/* Cards */
+.card {
+  background: var(--bg-light);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 16px 20px;
+}
+
+.card-label {
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+
+/* Heatmap */
+.heatmap-card {
+  margin-bottom: 16px;
+}
+
+.heatmap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 14px;
+}
+
+.heatmap-summary {
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.heatmap-stats {
+  display: flex;
+  gap: 16px;
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.heatmap-stats .stat-value {
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.heatmap-legend-label {
+  font-size: 9px;
+  color: var(--text-secondary);
+}
+
+.heatmap-legend-cell {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+}
+
+/* Heatmap tooltip */
+.heatmap-tooltip {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  background: var(--primary-dark);
+  color: #fff;
+  padding: 5px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  line-height: 1.5;
+}
+
+.heatmap-tooltip-title {
+  font-weight: 600;
+}
+
+.heatmap-tooltip-sub {
+  opacity: 0.75;
+}
+
+/* Analytics grid */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.analytics-card {
+  min-height: 120px;
+}
+
+/* Sparkline */
+.sparkline-svg {
+  display: block;
+}
+
+/* Domain chart */
+.domain-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.domain-favicon {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2px;
-  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  overflow: hidden;
 }
 
-.history-item:hover .delete-button {
+.domain-favicon img {
+  width: 14px;
+  height: 14px;
+}
+
+.domain-favicon-fallback {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-color);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 7px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.domain-name {
+  width: 120px;
+  font-size: 10px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.domain-bar-track {
+  flex: 1;
+  height: 14px;
+  background: var(--bg-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+}
+
+.domain-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--border-color), var(--primary-color));
+  border-radius: var(--radius-sm);
+  transition: width 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.domain-duration {
+  width: 44px;
+  font-size: 9px;
+  color: var(--text-color);
+  font-weight: 600;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Search + filter row */
+.search-filter-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+}
+
+.search-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-light);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 0 12px;
+  height: 36px;
+}
+
+.search-box-icon {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.search-box input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: var(--font-sm);
+  color: var(--text-color);
+  outline: none;
+}
+
+.search-clear-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+}
+
+.time-range-group {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-light);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  border: 1px solid var(--border-color);
+}
+
+.time-range-btn {
+  padding: 4px 10px;
+  font-size: 10px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 500;
+  transition: all var(--transition-fast);
+}
+
+.time-range-btn.active {
+  background: var(--bg-light);
+  color: var(--primary-color);
+  box-shadow: var(--shadow-sm);
+}
+
+/* History list */
+.history-list {
+  max-height: calc(100vh - 500px);
+  min-height: 200px;
+  overflow-y: auto;
+}
+
+/* Date group */
+.date-group-label {
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--primary-color);
+  padding: 6px 12px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  background: var(--bg-color);
+  z-index: 2;
+  text-transform: capitalize;
+}
+
+/* Session group */
+.session-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+}
+
+.session-header:hover {
+  background: var(--bg-color);
+}
+
+.session-expand-icon {
+  font-size: 10px;
+  color: var(--text-secondary);
+  transition: transform var(--transition-fast);
+  display: inline-block;
+}
+
+.session-expand-icon.expanded {
+  transform: rotate(90deg);
+}
+
+.session-time {
+  font-size: var(--font-xs);
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+.session-dash {
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+}
+
+.session-meta {
+  font-size: var(--font-xs);
+  color: var(--text-secondary);
+}
+
+.session-domains {
+  flex: 1;
+  display: flex;
+  gap: 3px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.session-domain-badge {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.session-domain-badge img {
+  width: 16px;
+  height: 16px;
+}
+
+.session-domain-more {
+  font-size: 8px;
+  color: var(--text-secondary);
+  align-self: center;
+}
+
+.session-delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-xs);
+  color: var(--border-color);
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast);
+}
+
+.session-delete-btn:hover {
+  color: var(--error-color);
+}
+
+/* Session entries */
+.session-entries {
+  margin-left: 20px;
+  border-left: 1px solid var(--border-color);
+  padding-left: 12px;
+}
+
+/* History entry */
+.history-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  transition: background var(--transition-fast);
+}
+
+.history-entry:hover {
+  background: var(--bg-color);
+}
+
+.history-entry input[type="checkbox"] {
+  accent-color: var(--primary-color);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.entry-time {
+  font-size: 10px;
+  color: var(--text-secondary);
+  width: 42px;
+  flex-shrink: 0;
+}
+
+.entry-favicon {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.entry-favicon img {
+  width: 14px;
+  height: 14px;
+}
+
+.entry-favicon-fallback {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-color);
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+}
+
+.entry-title {
+  font-size: var(--font-sm);
+  color: var(--text-color);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.entry-title:hover {
+  text-decoration: underline;
+}
+
+.entry-domain {
+  font-size: 9px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.entry-duration {
+  display: flex;
+  font-size: 9px;
+  flex-shrink: 0;
+  background: var(--bg-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+}
+
+.entry-active-dur {
+  padding: 1px 5px;
+  color: var(--text-color);
+  font-weight: 600;
+}
+
+.entry-total-dur {
+  padding: 1px 5px;
+  color: var(--text-secondary);
+  border-left: 1px solid var(--border-color);
+}
+
+.entry-delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--border-color);
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+}
+
+.history-entry:hover .entry-delete-btn {
   opacity: 0.6;
 }
 
-.delete-button:hover {
+.entry-delete-btn:hover {
   opacity: 1 !important;
+  color: var(--error-color);
 }
 
-.empty-state {
-  padding: var(--spacing-md);
+/* Empty state */
+.no-history {
   text-align: center;
-  color: var(--text-secondary);
-}
-
-.history-stats {
-  margin-top: var(--spacing-md);
+  padding: 48px 0;
   color: var(--text-secondary);
   font-size: var(--font-sm);
-  text-align: center;
 }
 
-.clear-all-button {
-  margin: var(--spacing-md) auto !important;
-  text-align: center !important;
-  font-size: var(--font-sm) !important;
+.no-history i {
+  margin-bottom: 12px;
+  opacity: 0.4;
 }
 
+.no-history p {
+  margin: 0;
+}
+
+/* Loading */
 .loading-indicator {
   text-align: center;
   padding: var(--spacing-sm);
   color: var(--text-secondary);
   font-size: var(--font-sm);
+}
+
+/* Scrollbar */
+.history-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.history-list::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 2px;
 }

--- a/src/renderer/pages/history/index.css
+++ b/src/renderer/pages/history/index.css
@@ -1,13 +1,10 @@
 @import url("../../styles/global.css");
 
-/* Page layout */
+/* Page layout — inherits font from global.css */
 .history-page {
   min-height: 100vh;
   background: var(--bg-color);
   color: var(--text-color);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  font-size: var(--font-sm);
-  line-height: 1.5;
 }
 
 .history-container {
@@ -51,7 +48,6 @@
 .btn-clear-all {
   padding: 4px 10px;
   font-size: var(--font-xs);
-  font-family: inherit;
   background: var(--bg-light);
   color: var(--text-secondary);
   border: 1px solid var(--border-color);
@@ -172,15 +168,22 @@
 }
 
 .analytics-card {
-  min-height: 120px;
+  min-height: 140px;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
-/* Sparkline */
+/* Sparkline — fills available card space */
+#sparkline-container {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+}
+
 .sparkline-svg {
   display: block;
   width: 100%;
-  height: auto;
 }
 
 /* Domain chart */
@@ -321,7 +324,6 @@
   border: none;
   background: transparent;
   font-size: var(--font-sm);
-  font-family: inherit;
   color: var(--text-color);
   outline: none;
 }
@@ -347,8 +349,7 @@
 
 .time-range-btn {
   padding: 4px 10px;
-  font-size: 10px;
-  font-family: inherit;
+  font-size: var(--font-xs);
   background: transparent;
   color: var(--text-secondary);
   border: none;

--- a/src/renderer/pages/history/index.css
+++ b/src/renderer/pages/history/index.css
@@ -5,6 +5,9 @@
   min-height: 100vh;
   background: var(--bg-color);
   color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  font-size: var(--font-sm);
+  line-height: 1.5;
 }
 
 .history-container {
@@ -45,23 +48,10 @@
   align-items: center;
 }
 
-.btn-delete-selected {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  font-size: var(--font-xs);
-  background: var(--error-light);
-  color: var(--error-color);
-  border: 1px solid #fecaca;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  font-weight: 500;
-}
-
 .btn-clear-all {
   padding: 4px 10px;
   font-size: var(--font-xs);
+  font-family: inherit;
   background: var(--bg-light);
   color: var(--text-secondary);
   border: 1px solid var(--border-color);
@@ -119,6 +109,18 @@
   font-weight: 600;
 }
 
+.heatmap-scroll-area {
+  position: relative;
+  overflow-x: auto;
+  overflow-y: visible;
+}
+
+.heatmap-scroll-area svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
 .heatmap-legend {
   display: flex;
   align-items: center;
@@ -164,18 +166,21 @@
 /* Analytics grid */
 .analytics-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   gap: 16px;
   margin-bottom: 20px;
 }
 
 .analytics-card {
   min-height: 120px;
+  overflow: hidden;
 }
 
 /* Sparkline */
 .sparkline-svg {
   display: block;
+  width: 100%;
+  height: auto;
 }
 
 /* Domain chart */
@@ -217,7 +222,7 @@
 }
 
 .domain-name {
-  width: 120px;
+  width: 100px;
   font-size: 10px;
   color: var(--text-secondary);
   overflow: hidden;
@@ -251,6 +256,42 @@
   flex-shrink: 0;
 }
 
+/* Category chart */
+.category-chart-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.category-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.category-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+}
+
+.category-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.category-legend-name {
+  color: var(--text-secondary);
+  width: 72px;
+}
+
+.category-legend-pct {
+  color: var(--text-light);
+}
+
 /* Search + filter row */
 .search-filter-row {
   display: flex;
@@ -280,6 +321,7 @@
   border: none;
   background: transparent;
   font-size: var(--font-sm);
+  font-family: inherit;
   color: var(--text-color);
   outline: none;
 }
@@ -306,6 +348,7 @@
 .time-range-btn {
   padding: 4px 10px;
   font-size: 10px;
+  font-family: inherit;
   background: transparent;
   color: var(--text-secondary);
   border: none;
@@ -321,11 +364,9 @@
   box-shadow: var(--shadow-sm);
 }
 
-/* History list */
+/* History list — no inner scroll, uses page scroll */
 .history-list {
-  max-height: calc(100vh - 500px);
-  min-height: 200px;
-  overflow-y: auto;
+  /* no max-height or overflow — page scrolls naturally */
 }
 
 /* Date group */
@@ -434,7 +475,7 @@
   padding-left: 12px;
 }
 
-/* History entry */
+/* History entry — no checkbox */
 .history-entry {
   display: flex;
   align-items: center;
@@ -447,12 +488,6 @@
 
 .history-entry:hover {
   background: var(--bg-color);
-}
-
-.history-entry input[type="checkbox"] {
-  accent-color: var(--primary-color);
-  cursor: pointer;
-  flex-shrink: 0;
 }
 
 .entry-time {
@@ -577,14 +612,4 @@
   padding: var(--spacing-sm);
   color: var(--text-secondary);
   font-size: var(--font-sm);
-}
-
-/* Scrollbar */
-.history-list::-webkit-scrollbar {
-  width: 4px;
-}
-
-.history-list::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 2px;
 }

--- a/src/renderer/pages/history/index.html
+++ b/src/renderer/pages/history/index.html
@@ -11,14 +11,10 @@
       <!-- Header -->
       <div class="history-header">
         <div class="history-header-left">
-          <h1 class="history-title">History</h1>
+          <h1 class="history-title">history</h1>
           <span id="history-stats" class="history-stats-label"></span>
         </div>
         <div class="history-header-right">
-          <button id="delete-selected" class="btn-delete-selected" style="display:none;">
-            <i data-lucide="trash-2" width="12" height="12"></i>
-            <span id="delete-selected-count"></span>
-          </button>
           <button id="delete-all" class="btn-clear-all" style="display:none;">Clear All</button>
         </div>
       </div>
@@ -35,6 +31,10 @@
         <div class="card analytics-card">
           <div class="card-label">top sites &middot; active time</div>
           <div id="domain-chart-container"></div>
+        </div>
+        <div class="card analytics-card">
+          <div class="card-label">time by category</div>
+          <div id="category-container"></div>
         </div>
       </div>
 
@@ -65,6 +65,9 @@
 
       <!-- Loading -->
       <div id="loading-indicator" class="loading-indicator" style="display:none;">Loading...</div>
+
+      <!-- Infinite scroll sentinel -->
+      <div id="scroll-sentinel" style="height:1px;"></div>
     </div>
   </div>
 </body>

--- a/src/renderer/pages/history/index.html
+++ b/src/renderer/pages/history/index.html
@@ -5,38 +5,67 @@
   <title>Browsing History</title>
 </head>
 <body>
-  <!-- Hero Section -->
-  <section class="hero-section">
-    <div class="container text-center">
-        <h1 class="mb-sm">Browsing History</h1>
-        <p>View and manage your local browsing history</p>
-    </div>
-  </section>
-
-  <!-- Main Content -->
-  <main class="container">
-    <!-- Search Bar -->
-    <div class="search-container">
-        <input type="text" id="search-input" class="search-input" placeholder="Search history...">
-        <i data-lucide="search" class="search-icon" width="16" height="16"></i>
-    </div>
-    
-    <!-- History Container -->
+  <div class="history-page">
     <div class="history-container">
-        <div id="history-list" class="history-list">
-            <!-- History items will be dynamically inserted here -->
+
+      <!-- Header -->
+      <div class="history-header">
+        <div class="history-header-left">
+          <h1 class="history-title">History</h1>
+          <span id="history-stats" class="history-stats-label"></span>
         </div>
-				<div id="no-history" class="no-history">
-					No browsing history saved yet.
-				</div>
+        <div class="history-header-right">
+          <button id="delete-selected" class="btn-delete-selected" style="display:none;">
+            <i data-lucide="trash-2" width="12" height="12"></i>
+            <span id="delete-selected-count"></span>
+          </button>
+          <button id="delete-all" class="btn-clear-all" style="display:none;">Clear All</button>
+        </div>
+      </div>
+
+      <!-- Heatmap -->
+      <div id="heatmap-container" class="card heatmap-card"></div>
+
+      <!-- Analytics Row -->
+      <div class="analytics-grid">
+        <div class="card analytics-card">
+          <div class="card-label">activity &middot; 14 days</div>
+          <div id="sparkline-container"></div>
+        </div>
+        <div class="card analytics-card">
+          <div class="card-label">top sites &middot; active time</div>
+          <div id="domain-chart-container"></div>
+        </div>
+      </div>
+
+      <!-- Search + Filters -->
+      <div class="search-filter-row">
+        <div class="search-box">
+          <i data-lucide="search" width="14" height="14" class="search-box-icon"></i>
+          <input type="text" id="search-input" placeholder="Search history..." />
+          <button id="search-clear" class="search-clear-btn" style="display:none;">
+            <i data-lucide="x" width="12" height="12"></i>
+          </button>
+        </div>
+        <div class="time-range-group">
+          <button class="time-range-btn active" data-range="all">all</button>
+          <button class="time-range-btn" data-range="week">week</button>
+          <button class="time-range-btn" data-range="today">today</button>
+        </div>
+      </div>
+
+      <!-- Session-grouped history -->
+      <div id="history-list" class="history-list"></div>
+
+      <!-- Empty state -->
+      <div id="no-history" class="no-history" style="display:none;">
+        <i data-lucide="clock" width="32" height="32"></i>
+        <p>No browsing history found</p>
+      </div>
+
+      <!-- Loading -->
+      <div id="loading-indicator" class="loading-indicator" style="display:none;">Loading...</div>
     </div>
-    
-    <!-- History Stats and Clear Button -->
-    <div class="history-stats">
-			<div class="text-center">
-				<button id="delete-all" class="btn clear-all-button">Clear All History</button>
-			</div>
-    </div>
-</main>
+  </div>
 </body>
 </html>

--- a/src/renderer/pages/history/index.html
+++ b/src/renderer/pages/history/index.html
@@ -25,15 +25,15 @@
       <!-- Analytics Row -->
       <div class="analytics-grid">
         <div class="card analytics-card">
-          <div class="card-label">activity &middot; 14 days</div>
+          <div class="card-label" id="sparkline-label">activity &middot; 14 days</div>
           <div id="sparkline-container"></div>
         </div>
         <div class="card analytics-card">
-          <div class="card-label">top sites &middot; active time</div>
+          <div class="card-label" id="domain-chart-label">top sites</div>
           <div id="domain-chart-container"></div>
         </div>
         <div class="card analytics-card">
-          <div class="card-label">time by category</div>
+          <div class="card-label" id="category-label">by category</div>
           <div id="category-container"></div>
         </div>
       </div>

--- a/src/renderer/pages/history/index.ts
+++ b/src/renderer/pages/history/index.ts
@@ -11,6 +11,45 @@ const PAGE_SIZE = 100;
 const SESSION_GAP_MS = 1800000; // 30 minutes
 const HEATMAP_LEVELS = ['#f0f0f0', '#d4d4d4', '#a3a3a3', '#525252', '#171717'];
 
+// Domain-to-category mapping for the pie chart
+const DOMAIN_CATEGORIES: Record<string, string> = {
+  'github.com': 'dev', 'gitlab.com': 'dev', 'stackoverflow.com': 'dev',
+  'npmjs.com': 'dev', 'developer.mozilla.org': 'dev', 'docs.python.org': 'dev',
+  'crates.io': 'dev', 'pkg.go.dev': 'dev', 'pypi.org': 'dev',
+  'vercel.com': 'dev', 'netlify.com': 'dev', 'heroku.com': 'dev',
+  'linear.app': 'dev', 'jira.atlassian.com': 'dev', 'bitbucket.org': 'dev',
+  'twitter.com': 'social', 'x.com': 'social', 'facebook.com': 'social',
+  'reddit.com': 'social', 'instagram.com': 'social', 'linkedin.com': 'social',
+  'threads.net': 'social', 'mastodon.social': 'social', 'discord.com': 'social',
+  'youtube.com': 'media', 'twitch.tv': 'media', 'vimeo.com': 'media',
+  'netflix.com': 'media', 'spotify.com': 'media', 'soundcloud.com': 'media',
+  'news.ycombinator.com': 'news', 'techcrunch.com': 'news', 'medium.com': 'news',
+  'bbc.com': 'news', 'nytimes.com': 'news', 'theguardian.com': 'news',
+  'cnn.com': 'news', 'reuters.com': 'news', 'arstechnica.com': 'news',
+  'google.com': 'search', 'bing.com': 'search', 'duckduckgo.com': 'search',
+  'gmail.com': 'productivity', 'outlook.com': 'productivity', 'notion.so': 'productivity',
+  'calendar.google.com': 'productivity', 'docs.google.com': 'productivity',
+  'drive.google.com': 'productivity', 'slack.com': 'productivity',
+  'amazon.com': 'shopping', 'ebay.com': 'shopping', 'etsy.com': 'shopping',
+  'wikipedia.org': 'reference', 'arxiv.org': 'reference', 'mdn.io': 'reference',
+  'figma.com': 'design', 'dribbble.com': 'design', 'behance.net': 'design',
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  dev: '#171717', social: '#404040', media: '#525252', news: '#737373',
+  search: '#8a8a8a', productivity: '#a3a3a3', shopping: '#bdbdbd',
+  reference: '#d4d4d4', design: '#e0e0e0', other: '#f0f0f0',
+};
+
+function getCategoryForDomain(domain: string): string {
+  if (DOMAIN_CATEGORIES[domain]) return DOMAIN_CATEGORIES[domain];
+  // Check if any key is a suffix match (e.g. "sub.github.com" → "github.com")
+  for (const [d, cat] of Object.entries(DOMAIN_CATEGORIES)) {
+    if (domain.endsWith('.' + d)) return cat;
+  }
+  return 'other';
+}
+
 // --- State ---
 let allEntries: BrowsingHistoryRecord[] = [];
 let currentOffset = 0;
@@ -18,20 +57,18 @@ let isLoading = false;
 let hasMore = true;
 let currentSearchTerm = '';
 let currentTimeRange = 'all';
-const selectedIds = new Set<string>();
 
 // --- DOM refs ---
 const historyList = document.getElementById('history-list') as HTMLElement;
 const searchInput = document.getElementById('search-input') as HTMLInputElement;
 const searchClear = document.getElementById('search-clear') as HTMLElement;
-const deleteSelectedBtn = document.getElementById('delete-selected') as HTMLElement;
-const deleteSelectedCount = document.getElementById('delete-selected-count') as HTMLElement;
 const deleteAllBtn = document.getElementById('delete-all') as HTMLElement;
 const noHistory = document.getElementById('no-history') as HTMLElement;
 const statsLabel = document.getElementById('history-stats') as HTMLElement;
 const heatmapContainer = document.getElementById('heatmap-container') as HTMLElement;
 const sparklineContainer = document.getElementById('sparkline-container') as HTMLElement;
 const domainChartContainer = document.getElementById('domain-chart-container') as HTMLElement;
+const categoryContainer = document.getElementById('category-container') as HTMLElement;
 
 // --- Init ---
 document.addEventListener('DOMContentLoaded', async () => {
@@ -61,19 +98,19 @@ document.addEventListener('DOMContentLoaded', async () => {
   deleteAllBtn?.addEventListener('click', async () => {
     await window.BrowserAPI.removeAllBrowsingHistory(window.BrowserAPI.appWindowId);
     allEntries = [];
-    selectedIds.clear();
     renderAll();
   });
 
-  deleteSelectedBtn?.addEventListener('click', deleteSelected);
-
-  historyList?.addEventListener('scroll', () => {
-    if (isLoading || !hasMore) return;
-    const { scrollTop, scrollHeight, clientHeight } = historyList;
-    if (scrollTop + clientHeight >= scrollHeight - 100) {
-      loadHistoryPage();
-    }
-  });
+  // Infinite scroll via IntersectionObserver on sentinel element
+  const sentinel = document.getElementById('scroll-sentinel');
+  if (sentinel) {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !isLoading && hasMore) {
+        loadHistoryPage();
+      }
+    }, { rootMargin: '200px' });
+    observer.observe(sentinel);
+  }
 });
 
 // --- Data loading ---
@@ -87,7 +124,6 @@ function resetAndReload(): void {
   currentOffset = 0;
   hasMore = true;
   allEntries = [];
-  selectedIds.clear();
   historyList.innerHTML = '';
   loadHistoryPage();
 }
@@ -108,7 +144,6 @@ async function loadHistoryPage(): Promise<void> {
 
   if (data.length < PAGE_SIZE) hasMore = false;
 
-  // Apply client-side time range filter
   const filtered = filterByTimeRange(data);
   allEntries = allEntries.concat(filtered);
   currentOffset += data.length;
@@ -135,8 +170,8 @@ function renderAll(): void {
   renderHistoryList();
   renderSparkline();
   renderDomainChart();
+  renderCategoryChart();
   updateStats();
-  updateSelectionUI();
 
   const hasEntries = allEntries.length > 0;
   noHistory.style.display = hasEntries ? 'none' : 'block';
@@ -149,25 +184,6 @@ function updateStats(): void {
   statsLabel.textContent = `${allEntries.length.toLocaleString()} pages \u00b7 ${totalDomains} sites \u00b7 ${FormatUtils.formatDuration(totalActive)} active`;
 }
 
-function updateSelectionUI(): void {
-  if (selectedIds.size > 0) {
-    deleteSelectedBtn.style.display = 'inline-flex';
-    deleteSelectedCount.textContent = `delete ${selectedIds.size} selected`;
-  } else {
-    deleteSelectedBtn.style.display = 'none';
-  }
-}
-
-async function deleteSelected(): Promise<void> {
-  const ids = Array.from(selectedIds);
-  for (const id of ids) {
-    await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, id);
-  }
-  allEntries = allEntries.filter(e => !selectedIds.has(e.id));
-  selectedIds.clear();
-  renderAll();
-}
-
 // --- Session grouping ---
 interface Session { entries: BrowsingHistoryRecord[] }
 interface DateGroup { label: string; dateKey: string; sessions: Session[] }
@@ -175,7 +191,6 @@ interface DateGroup { label: string; dateKey: string; sessions: Session[] }
 function groupIntoSessions(entries: BrowsingHistoryRecord[]): DateGroup[] {
   if (entries.length === 0) return [];
 
-  // Group by date first
   const dateMap = new Map<string, BrowsingHistoryRecord[]>();
   for (const entry of entries) {
     const d = new Date(entry.createdDate);
@@ -186,10 +201,8 @@ function groupIntoSessions(entries: BrowsingHistoryRecord[]): DateGroup[] {
 
   const dateGroups: DateGroup[] = [];
   for (const [dateKey, dayEntries] of dateMap) {
-    // Sort descending within day
     dayEntries.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
 
-    // Group into sessions by 30-min gap
     const sessions: Session[] = [];
     let currentSession: BrowsingHistoryRecord[] = [dayEntries[0]];
 
@@ -219,13 +232,11 @@ function renderHistoryList(): void {
   const dateGroups = groupIntoSessions(allEntries);
 
   for (const dg of dateGroups) {
-    // Date label
     const dateLabel = document.createElement('div');
     dateLabel.className = 'date-group-label';
     dateLabel.textContent = dg.label;
     historyList.appendChild(dateLabel);
 
-    // Sessions
     for (const session of dg.sessions) {
       renderSession(session, historyList);
     }
@@ -242,14 +253,12 @@ function renderSession(session: Session, container: HTMLElement): void {
   const sessionActive = session.entries.reduce((a, e) => a + (e.activeDuration || 0), 0);
   const uniqueDomains = [...new Set(session.entries.map(e => e.topLevelDomain))];
 
-  // Session header
   const header = document.createElement('div');
   header.className = 'session-header';
   let expanded = true;
 
   const startTime = new Date(lastEntry.createdDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-  // Build domain badges HTML
   const domainBadgesHtml = uniqueDomains.slice(0, 6).map(domain => {
     const faviconUrl = `https://${domain}/favicon.ico`;
     return `<span class="session-domain-badge"><img src="${faviconUrl}" onerror="this.parentElement.innerHTML='&#x1F310;'" width="16" height="16"></span>`;
@@ -282,19 +291,17 @@ function renderSession(session: Session, container: HTMLElement): void {
     }
     const ids = new Set(session.entries.map(e => e.id));
     allEntries = allEntries.filter(e => !ids.has(e.id));
-    ids.forEach(id => selectedIds.delete(id));
     wrapper.remove();
     renderSparkline();
     renderDomainChart();
+    renderCategoryChart();
     updateStats();
-    updateSelectionUI();
     if (allEntries.length === 0) {
       noHistory.style.display = 'block';
       deleteAllBtn.style.display = 'none';
     }
   });
 
-  // Render entries
   for (const entry of session.entries) {
     entriesDiv.appendChild(renderEntry(entry));
   }
@@ -312,7 +319,6 @@ function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
   const faviconUrl = entry.faviconUrl || `https://${entry.topLevelDomain}/favicon.ico`;
 
   row.innerHTML = `
-    <input type="checkbox" ${selectedIds.has(entry.id) ? 'checked' : ''} />
     <span class="entry-time">${time}</span>
     <span class="entry-favicon"><img src="${faviconUrl}" width="14" height="14" onerror="this.parentElement.innerHTML='<span class=\\'entry-favicon-fallback\\'>&#x1F310;</span>'"></span>
     <span class="entry-title" title="${escapeHtml(entry.title)}">${escapeHtml(entry.title)}</span>
@@ -324,12 +330,6 @@ function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
     <button class="entry-delete-btn"><i data-lucide="x" width="12" height="12"></i></button>
   `;
 
-  row.querySelector('input[type="checkbox"]')?.addEventListener('change', () => {
-    if (selectedIds.has(entry.id)) selectedIds.delete(entry.id);
-    else selectedIds.add(entry.id);
-    updateSelectionUI();
-  });
-
   row.querySelector('.entry-title')?.addEventListener('click', () => {
     window.BrowserAPI.createTab(window.BrowserAPI.appWindowId, entry.url, true);
   });
@@ -338,12 +338,11 @@ function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
     e.stopPropagation();
     await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, entry.id);
     allEntries = allEntries.filter(item => item.id !== entry.id);
-    selectedIds.delete(entry.id);
     row.remove();
     renderSparkline();
     renderDomainChart();
+    renderCategoryChart();
     updateStats();
-    updateSelectionUI();
     if (allEntries.length === 0) {
       noHistory.style.display = 'block';
       deleteAllBtn.style.display = 'none';
@@ -353,7 +352,7 @@ function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
   return row;
 }
 
-// --- Heatmap ---
+// --- Heatmap (responsive SVG via viewBox) ---
 function renderHeatmap(stats: Array<{ date: string; count: number; activeDuration: number }>): void {
   const now = new Date();
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
@@ -361,13 +360,11 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
   const startDate = new Date(todayStart);
   startDate.setDate(startDate.getDate() - (52 * 7 + currentDow));
 
-  // Build day map from stats
   const dayMap = new Map<string, { count: number; active: number }>();
   for (const s of stats) {
     dayMap.set(s.date, { count: s.count, active: s.activeDuration });
   }
 
-  // Build weeks
   type DayCell = { date: Date; dow: number; count: number; active: number; label: string };
   const weeks: DayCell[][] = [];
   let currentWeek: DayCell[] = [];
@@ -416,14 +413,14 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
 
   const cellSize = 11;
   const cellGap = 2;
-  const dayLabelW = 24;
+  const dayLabelW = 28;
   const topPad = 18;
   const gridW = weeks.length * (cellSize + cellGap);
   const gridH = 7 * (cellSize + cellGap);
-  const dayLabels = ['', 'mon', '', 'wed', '', 'fri', ''];
+  const dayLabels = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
 
   function getLevel(count: number): number {
-    if (count === 0) return 0;
+    if (count === 0 || maxCount === 0) return 0;
     const ratio = count / maxCount;
     if (ratio <= 0.25) return 1;
     if (ratio <= 0.5) return 2;
@@ -431,7 +428,6 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
     return 4;
   }
 
-  // Build HTML
   let svgContent = '';
 
   // Month labels
@@ -439,11 +435,9 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
     svgContent += `<text x="${dayLabelW + m.weekIndex * (cellSize + cellGap)}" y="12" font-size="9" fill="var(--text-secondary)">${m.month}</text>`;
   }
 
-  // Day labels
+  // Day labels — show all 7 days
   for (let i = 0; i < dayLabels.length; i++) {
-    if (dayLabels[i]) {
-      svgContent += `<text x="0" y="${topPad + i * (cellSize + cellGap) + cellSize - 1}" font-size="8" fill="var(--text-secondary)">${dayLabels[i]}</text>`;
-    }
+    svgContent += `<text x="0" y="${topPad + i * (cellSize + cellGap) + cellSize - 1}" font-size="8" fill="var(--text-secondary)">${dayLabels[i]}</text>`;
   }
 
   // Cells
@@ -457,7 +451,7 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
     }
   }
 
-  const svgW = dayLabelW + gridW + 8;
+  const svgW = dayLabelW + gridW + 4;
   const svgH = topPad + gridH + 4;
 
   heatmapContainer.innerHTML = `
@@ -468,8 +462,8 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
         <span><span class="stat-value">${FormatUtils.formatDuration(totalActive)}</span> active time</span>
       </div>
     </div>
-    <div style="position:relative;overflow-x:auto;overflow-y:visible;">
-      <svg width="${svgW}" height="${svgH}" style="display:block;">${svgContent}</svg>
+    <div class="heatmap-scroll-area">
+      <svg viewBox="0 0 ${svgW} ${svgH}" preserveAspectRatio="xMinYMid meet">${svgContent}</svg>
       <div class="heatmap-legend">
         <span class="heatmap-legend-label">less</span>
         ${HEATMAP_LEVELS.map(c => `<div class="heatmap-legend-cell" style="background:${c}"></div>`).join('')}
@@ -480,7 +474,7 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
 
   // Tooltip behavior
   const svgEl = heatmapContainer.querySelector('svg')!;
-  const tooltipContainer = heatmapContainer.querySelector('div[style*="position:relative"]') as HTMLElement;
+  const scrollArea = heatmapContainer.querySelector('.heatmap-scroll-area') as HTMLElement;
   let tooltip: HTMLElement | null = null;
 
   svgEl.addEventListener('mouseover', (e) => {
@@ -490,15 +484,15 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
     const count = parseInt(target.getAttribute('data-count') || '0');
     const active = parseInt(target.getAttribute('data-active') || '0');
     const rect = target.getBoundingClientRect();
-    const cr = tooltipContainer.getBoundingClientRect();
+    const cr = scrollArea.getBoundingClientRect();
 
     if (!tooltip) {
       tooltip = document.createElement('div');
       tooltip.className = 'heatmap-tooltip';
-      tooltipContainer.appendChild(tooltip);
+      scrollArea.appendChild(tooltip);
     }
     tooltip.innerHTML = `<div class="heatmap-tooltip-title">${label}</div><div class="heatmap-tooltip-sub">${count === 0 ? 'no activity' : `${count} pages \u00b7 ${FormatUtils.formatDuration(active)} active`}</div>`;
-    tooltip.style.left = `${rect.left - cr.left + cellSize / 2}px`;
+    tooltip.style.left = `${rect.left - cr.left + rect.width / 2}px`;
     tooltip.style.top = `${rect.top - cr.top - 4}px`;
     tooltip.style.display = 'block';
   });
@@ -511,9 +505,8 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
   });
 }
 
-// --- Sparkline ---
+// --- Sparkline (responsive, fills card) ---
 function renderSparkline(): void {
-  // Compute daily page counts for last 14 days
   const dailyData: { date: Date; count: number; active: number; label: string }[] = [];
   for (let i = 13; i >= 0; i--) {
     const d = new Date(Date.now() - i * 86400000);
@@ -532,16 +525,23 @@ function renderSparkline(): void {
     dailyData.push({ date: d, count, active, label });
   }
 
-  const maxActive = Math.max(...dailyData.map(d => d.active), 1);
-  const w = 280, h = 48;
+  // Use page count if all active durations are 0
+  const hasActiveData = dailyData.some(d => d.active > 0);
+  const values = dailyData.map(d => hasActiveData ? d.active : d.count);
+  const maxVal = Math.max(...values, 1);
+
+  // Use viewBox coordinates; actual size determined by CSS width:100%
+  const vw = 300, vh = 80;
+  const padTop = 8, padBot = 20, padX = 4;
+  const chartH = vh - padTop - padBot;
 
   const points = dailyData.map((d, i) => ({
-    x: (i / (dailyData.length - 1)) * w,
-    y: h - (d.active / maxActive) * (h - 8) - 4,
+    x: padX + (i / (dailyData.length - 1)) * (vw - padX * 2),
+    y: padTop + chartH - (values[i] / maxVal) * chartH,
     ...d,
   }));
 
-  // Build smooth curve
+  // Smooth curve
   let pathD = `M ${points[0].x} ${points[0].y}`;
   for (let i = 1; i < points.length; i++) {
     const prev = points[i - 1];
@@ -550,24 +550,26 @@ function renderSparkline(): void {
     pathD += ` C ${cpx} ${prev.y}, ${cpx} ${p.y}, ${p.x} ${p.y}`;
   }
 
+  const fillPath = `${pathD} L ${points[points.length - 1].x} ${padTop + chartH} L ${points[0].x} ${padTop + chartH} Z`;
+
   let dotsAndLabels = '';
   for (let i = 0; i < points.length; i++) {
     const p = points[i];
-    dotsAndLabels += `<circle cx="${p.x}" cy="${p.y}" r="2.5" fill="var(--bg-light)" stroke="var(--primary-color)" stroke-width="1.5" />`;
+    dotsAndLabels += `<circle cx="${p.x}" cy="${p.y}" r="3" fill="var(--bg-light)" stroke="var(--primary-color)" stroke-width="1.5" />`;
     if (i === 0 || i === points.length - 1 || i === 7) {
-      dotsAndLabels += `<text x="${p.x}" y="${h + 14}" text-anchor="middle" font-size="8" fill="var(--text-secondary)">${p.label}</text>`;
+      dotsAndLabels += `<text x="${p.x}" y="${vh - 2}" text-anchor="middle" font-size="9" fill="var(--text-secondary)">${p.label}</text>`;
     }
   }
 
   sparklineContainer.innerHTML = `
-    <svg class="sparkline-svg" width="${w}" height="${h + 16}" viewBox="0 0 ${w} ${h + 16}" style="overflow:visible">
+    <svg class="sparkline-svg" viewBox="0 0 ${vw} ${vh}" preserveAspectRatio="xMidYMid meet">
       <defs>
         <linearGradient id="spark-fill" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stop-color="var(--primary-color)" stop-opacity="0.1" />
           <stop offset="100%" stop-color="var(--primary-color)" stop-opacity="0" />
         </linearGradient>
       </defs>
-      <path d="${pathD} L ${w} ${h + 4} L 0 ${h + 4} Z" fill="url(#spark-fill)" />
+      <path d="${fillPath}" fill="url(#spark-fill)" />
       <path d="${pathD}" fill="none" stroke="var(--primary-color)" stroke-width="1.5" />
       ${dotsAndLabels}
     </svg>
@@ -576,7 +578,6 @@ function renderSparkline(): void {
 
 // --- Domain Chart ---
 function renderDomainChart(): void {
-  // Aggregate by domain
   const map = new Map<string, { domain: string; visits: number; active: number; faviconUrl: string }>();
   for (const e of allEntries) {
     const existing = map.get(e.topLevelDomain);
@@ -609,6 +610,48 @@ function renderDomainChart(): void {
       <span class="domain-duration">${FormatUtils.formatDuration(d.active)}</span>
     </div>
   `).join('');
+}
+
+// --- Category Pie Chart ---
+function renderCategoryChart(): void {
+  const catMap = new Map<string, number>();
+  for (const e of allEntries) {
+    const cat = getCategoryForDomain(e.topLevelDomain);
+    catMap.set(cat, (catMap.get(cat) || 0) + (e.activeDuration || 0));
+  }
+
+  const total = Array.from(catMap.values()).reduce((a, b) => a + b, 0) || 1;
+  const cats = Array.from(catMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([cat, dur]) => ({ cat, dur, pct: (dur / total) * 100 }));
+
+  // SVG donut chart
+  const radius = 32, circ = 2 * Math.PI * radius;
+  let accum = 0;
+  let slices = '';
+  for (const c of cats) {
+    const color = CATEGORY_COLORS[c.cat] || CATEGORY_COLORS.other;
+    const dashLen = (c.pct / 100) * circ;
+    const offset = -(accum / 100) * circ;
+    slices += `<circle cx="40" cy="40" r="${radius}" fill="none" stroke="${color}" stroke-width="10" stroke-dasharray="${dashLen} ${circ}" stroke-dashoffset="${offset}" />`;
+    accum += c.pct;
+  }
+
+  const legendHtml = cats.map(c => {
+    const color = CATEGORY_COLORS[c.cat] || CATEGORY_COLORS.other;
+    return `<div class="category-legend-item">
+      <div class="category-legend-dot" style="background:${color}"></div>
+      <span class="category-legend-name">${c.cat}</span>
+      <span class="category-legend-pct">${Math.round(c.pct)}%</span>
+    </div>`;
+  }).join('');
+
+  categoryContainer.innerHTML = `
+    <div class="category-chart-wrapper">
+      <svg width="80" height="80" viewBox="0 0 80 80">${slices}</svg>
+      <div class="category-legend">${legendHtml}</div>
+    </div>
+  `;
 }
 
 // --- Helpers ---

--- a/src/renderer/pages/history/index.ts
+++ b/src/renderer/pages/history/index.ts
@@ -389,7 +389,7 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
     const m = cursor.getMonth();
     if (m !== lastMonth) {
       monthLabels.push({
-        month: cursor.toLocaleDateString([], { month: 'short' }).toLowerCase(),
+        month: cursor.toLocaleDateString([], { month: 'short' }),
         weekIndex: weeks.length,
       });
       lastMonth = m;
@@ -400,7 +400,7 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
       dow: cursor.getDay(),
       count: data.count,
       active: data.active,
-      label: cursor.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' }).toLowerCase(),
+      label: cursor.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' }),
     });
 
     if (cursor.getDay() === 6 || cursor.getTime() === todayStart.getTime()) {
@@ -417,7 +417,7 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
   const topPad = 18;
   const gridW = weeks.length * (cellSize + cellGap);
   const gridH = 7 * (cellSize + cellGap);
-  const dayLabels = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+  const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   function getLevel(count: number): number {
     if (count === 0 || maxCount === 0) return 0;
@@ -430,9 +430,14 @@ function renderHeatmap(stats: Array<{ date: string; count: number; activeDuratio
 
   let svgContent = '';
 
-  // Month labels
+  // Month labels — skip labels that are too close together
+  let lastLabelX = -Infinity;
+  const minLabelGap = 30;
   for (const m of monthLabels) {
-    svgContent += `<text x="${dayLabelW + m.weekIndex * (cellSize + cellGap)}" y="12" font-size="9" fill="var(--text-secondary)">${m.month}</text>`;
+    const x = dayLabelW + m.weekIndex * (cellSize + cellGap);
+    if (x - lastLabelX < minLabelGap) continue;
+    svgContent += `<text x="${x}" y="12" font-size="9" fill="var(--text-secondary)">${m.month}</text>`;
+    lastLabelX = x;
   }
 
   // Day labels — show all 7 days
@@ -521,7 +526,7 @@ function renderSparkline(): void {
         active += e.activeDuration || 0;
       }
     }
-    const label = i === 0 ? 'today' : i === 1 ? 'yday' : d.toLocaleDateString([], { month: 'short', day: 'numeric' }).toLowerCase();
+    const label = i === 0 ? 'Today' : i === 1 ? 'Yday' : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
     dailyData.push({ date: d, count, active, label });
   }
 
@@ -614,16 +619,27 @@ function renderDomainChart(): void {
 
 // --- Category Pie Chart ---
 function renderCategoryChart(): void {
-  const catMap = new Map<string, number>();
-  for (const e of allEntries) {
-    const cat = getCategoryForDomain(e.topLevelDomain);
-    catMap.set(cat, (catMap.get(cat) || 0) + (e.activeDuration || 0));
+  if (allEntries.length === 0) {
+    categoryContainer.innerHTML = '';
+    return;
   }
 
+  // Aggregate by active duration; fall back to visit count if all durations are 0
+  const durationMap = new Map<string, number>();
+  const countMap = new Map<string, number>();
+  for (const e of allEntries) {
+    const cat = getCategoryForDomain(e.topLevelDomain);
+    durationMap.set(cat, (durationMap.get(cat) || 0) + (e.activeDuration || 0));
+    countMap.set(cat, (countMap.get(cat) || 0) + 1);
+  }
+
+  const totalDuration = Array.from(durationMap.values()).reduce((a, b) => a + b, 0);
+  const useDuration = totalDuration > 0;
+  const catMap = useDuration ? durationMap : countMap;
   const total = Array.from(catMap.values()).reduce((a, b) => a + b, 0) || 1;
   const cats = Array.from(catMap.entries())
     .sort((a, b) => b[1] - a[1])
-    .map(([cat, dur]) => ({ cat, dur, pct: (dur / total) * 100 }));
+    .map(([cat, val]) => ({ cat, dur: val, pct: (val / total) * 100 }));
 
   // SVG donut chart
   const radius = 32, circ = 2 * Math.PI * radius;

--- a/src/renderer/pages/history/index.ts
+++ b/src/renderer/pages/history/index.ts
@@ -317,16 +317,21 @@ function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
 
   const time = new Date(entry.createdDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   const faviconUrl = entry.faviconUrl || `https://${entry.topLevelDomain}/favicon.ico`;
+  const hasDuration = (entry.activeDuration || 0) > 0 || (entry.totalDuration || 0) > 0;
+
+  const durationHtml = hasDuration
+    ? `<div class="entry-duration">
+        <span class="entry-active-dur" title="active time">${FormatUtils.formatDuration(entry.activeDuration || 0)}</span>
+        <span class="entry-total-dur" title="total time">${FormatUtils.formatDuration(entry.totalDuration || 0)}</span>
+      </div>`
+    : '';
 
   row.innerHTML = `
     <span class="entry-time">${time}</span>
     <span class="entry-favicon"><img src="${faviconUrl}" width="14" height="14" onerror="this.parentElement.innerHTML='<span class=\\'entry-favicon-fallback\\'>&#x1F310;</span>'"></span>
     <span class="entry-title" title="${escapeHtml(entry.title)}">${escapeHtml(entry.title)}</span>
     <span class="entry-domain">${escapeHtml(entry.topLevelDomain)}</span>
-    <div class="entry-duration">
-      <span class="entry-active-dur" title="active time">${FormatUtils.formatDuration(entry.activeDuration || 0)}</span>
-      <span class="entry-total-dur" title="total time">${FormatUtils.formatDuration(entry.totalDuration || 0)}</span>
-    </div>
+    ${durationHtml}
     <button class="entry-delete-btn"><i data-lucide="x" width="12" height="12"></i></button>
   `;
 
@@ -535,6 +540,9 @@ function renderSparkline(): void {
   const values = dailyData.map(d => hasActiveData ? d.active : d.count);
   const maxVal = Math.max(...values, 1);
 
+  const sparkLabel = document.getElementById('sparkline-label');
+  if (sparkLabel) sparkLabel.textContent = hasActiveData ? 'active time \u00b7 14 days' : 'page visits \u00b7 14 days';
+
   // Use viewBox coordinates; actual size determined by CSS width:100%
   const vw = 300, vh = 80;
   const padTop = 8, padBot = 20, padX = 4;
@@ -599,22 +607,31 @@ function renderDomainChart(): void {
     }
   }
 
+  const totalActive = Array.from(map.values()).reduce((a, d) => a + d.active, 0);
+  const useTime = totalActive > 0;
+
   const sorted = Array.from(map.values())
-    .sort((a, b) => b.active - a.active)
+    .sort((a, b) => useTime ? b.active - a.active : b.visits - a.visits)
     .slice(0, 8);
 
-  const maxActive = Math.max(...sorted.map(d => d.active), 1);
+  const label = document.getElementById('domain-chart-label');
+  if (label) label.textContent = useTime ? 'top sites \u00b7 active time' : 'top sites \u00b7 visits';
 
-  domainChartContainer.innerHTML = sorted.map(d => `
+  const maxVal = Math.max(...sorted.map(d => useTime ? d.active : d.visits), 1);
+
+  domainChartContainer.innerHTML = sorted.map(d => {
+    const val = useTime ? d.active : d.visits;
+    const valLabel = useTime ? FormatUtils.formatDuration(d.active) : `${d.visits}`;
+    return `
     <div class="domain-row">
       <span class="domain-favicon"><img src="${d.faviconUrl}" width="14" height="14" onerror="this.parentElement.className='domain-favicon-fallback';this.parentElement.innerHTML='&#x1F310;'"></span>
       <span class="domain-name">${escapeHtml(d.domain)}</span>
       <div class="domain-bar-track">
-        <div class="domain-bar-fill" style="width:${(d.active / maxActive) * 100}%"></div>
+        <div class="domain-bar-fill" style="width:${(val / maxVal) * 100}%"></div>
       </div>
-      <span class="domain-duration">${FormatUtils.formatDuration(d.active)}</span>
-    </div>
-  `).join('');
+      <span class="domain-duration">${valLabel}</span>
+    </div>`;
+  }).join('');
 }
 
 // --- Category Pie Chart ---
@@ -640,6 +657,9 @@ function renderCategoryChart(): void {
   const cats = Array.from(catMap.entries())
     .sort((a, b) => b[1] - a[1])
     .map(([cat, val]) => ({ cat, dur: val, pct: (val / total) * 100 }));
+
+  const catLabel = document.getElementById('category-label');
+  if (catLabel) catLabel.textContent = useDuration ? 'time by category' : 'visits by category';
 
   // SVG donut chart
   const radius = 32, circ = 2 * Math.PI * radius;

--- a/src/renderer/pages/history/index.ts
+++ b/src/renderer/pages/history/index.ts
@@ -1,4 +1,3 @@
-
 import { HtmlUtils } from '../../../renderer/common/html-utils';
 import { FormatUtils } from '../../../renderer/common/format-utils';
 import { BrowsingHistoryRecord } from '../../../types/browsing-history-record';
@@ -7,132 +6,614 @@ import './index.css';
 import { createIcons, icons } from 'lucide';
 createIcons({ icons });
 
-const PAGE_SIZE = 50;
+// --- Constants ---
+const PAGE_SIZE = 100;
+const SESSION_GAP_MS = 1800000; // 30 minutes
+const HEATMAP_LEVELS = ['#f0f0f0', '#d4d4d4', '#a3a3a3', '#525252', '#171717'];
+
+// --- State ---
+let allEntries: BrowsingHistoryRecord[] = [];
 let currentOffset = 0;
 let isLoading = false;
 let hasMore = true;
 let currentSearchTerm = '';
-let allLoadedItems: BrowsingHistoryRecord[] = [];
+let currentTimeRange = 'all';
+const selectedIds = new Set<string>();
 
-const historyListElement = document.getElementById('history-list') as HTMLElement;
+// --- DOM refs ---
+const historyList = document.getElementById('history-list') as HTMLElement;
 const searchInput = document.getElementById('search-input') as HTMLInputElement;
+const searchClear = document.getElementById('search-clear') as HTMLElement;
+const deleteSelectedBtn = document.getElementById('delete-selected') as HTMLElement;
+const deleteSelectedCount = document.getElementById('delete-selected-count') as HTMLElement;
+const deleteAllBtn = document.getElementById('delete-all') as HTMLElement;
+const noHistory = document.getElementById('no-history') as HTMLElement;
+const statsLabel = document.getElementById('history-stats') as HTMLElement;
+const heatmapContainer = document.getElementById('heatmap-container') as HTMLElement;
+const sparklineContainer = document.getElementById('sparkline-container') as HTMLElement;
+const domainChartContainer = document.getElementById('domain-chart-container') as HTMLElement;
 
-document.addEventListener('DOMContentLoaded', async() => {
+// --- Init ---
+document.addEventListener('DOMContentLoaded', async () => {
   loadHistoryPage();
+  loadAnalytics();
 
-  document.getElementById('delete-all')?.addEventListener('click', async () => {
-    await window.BrowserAPI.removeAllBrowsingHistory(window.BrowserAPI.appWindowId);
-    historyListElement.innerHTML = '';
-    allLoadedItems = [];
-    document.getElementById('no-history').style.display = 'block';
-    document.getElementById('delete-all').style.display = 'none';
+  searchInput?.addEventListener('input', HtmlUtils.debounce(() => {
+    searchClear.style.display = searchInput.value ? 'flex' : 'none';
+    resetAndReload();
+  }, 300));
+
+  searchClear?.addEventListener('click', () => {
+    searchInput.value = '';
+    searchClear.style.display = 'none';
+    resetAndReload();
   });
 
-  const debouncedSearchHandler = HtmlUtils.debounce(() => {
-    resetAndReload();
-  }, 300);
-  document.getElementById('search-input')?.addEventListener('input', debouncedSearchHandler);
+  document.querySelectorAll('.time-range-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.time-range-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      currentTimeRange = (btn as HTMLElement).dataset.range || 'all';
+      resetAndReload();
+    });
+  });
 
-  historyListElement.addEventListener('scroll', () => {
+  deleteAllBtn?.addEventListener('click', async () => {
+    await window.BrowserAPI.removeAllBrowsingHistory(window.BrowserAPI.appWindowId);
+    allEntries = [];
+    selectedIds.clear();
+    renderAll();
+  });
+
+  deleteSelectedBtn?.addEventListener('click', deleteSelected);
+
+  historyList?.addEventListener('scroll', () => {
     if (isLoading || !hasMore) return;
-    const { scrollTop, scrollHeight, clientHeight } = historyListElement;
+    const { scrollTop, scrollHeight, clientHeight } = historyList;
     if (scrollTop + clientHeight >= scrollHeight - 100) {
       loadHistoryPage();
     }
   });
 });
 
-const resetAndReload = () => {
+// --- Data loading ---
+async function loadAnalytics(): Promise<void> {
+  const stats: Array<{ date: string; count: number; activeDuration: number }> =
+    await window.BrowserAPI.fetchBrowsingHistoryStats(window.BrowserAPI.appWindowId);
+  renderHeatmap(stats);
+}
+
+function resetAndReload(): void {
   currentOffset = 0;
   hasMore = true;
-  allLoadedItems = [];
-  historyListElement.innerHTML = '';
+  allEntries = [];
+  selectedIds.clear();
+  historyList.innerHTML = '';
   loadHistoryPage();
-};
+}
 
-const loadHistoryPage = async (): Promise<void> => {
+async function loadHistoryPage(): Promise<void> {
   if (isLoading || !hasMore) return;
   isLoading = true;
   currentSearchTerm = searchInput.value || '';
 
-  showLoadingIndicator();
+  const loadingEl = document.getElementById('loading-indicator') as HTMLElement;
+  loadingEl.style.display = 'block';
 
-  const historyData: Array<BrowsingHistoryRecord> = await window.BrowserAPI.fetchBrowsingHistory(
+  const data: BrowsingHistoryRecord[] = await window.BrowserAPI.fetchBrowsingHistory(
     window.BrowserAPI.appWindowId, currentSearchTerm, PAGE_SIZE, currentOffset
   );
 
-  removeLoadingIndicator();
+  loadingEl.style.display = 'none';
 
-  if (historyData.length < PAGE_SIZE) {
-    hasMore = false;
-  }
+  if (data.length < PAGE_SIZE) hasMore = false;
 
-  if (currentOffset === 0 && historyData.length === 0) {
-    document.getElementById('no-history').style.display = 'block';
-    document.getElementById('delete-all').style.display = 'none';
-    isLoading = false;
-    return;
-  } else {
-    document.getElementById('no-history').style.display = 'none';
-    document.getElementById('delete-all').style.display = 'block';
-  }
+  // Apply client-side time range filter
+  const filtered = filterByTimeRange(data);
+  allEntries = allEntries.concat(filtered);
+  currentOffset += data.length;
 
-  allLoadedItems = allLoadedItems.concat(historyData);
-  currentOffset += historyData.length;
-
-  appendHistoryItems(historyData);
+  renderAll();
   isLoading = false;
-};
+}
 
-const appendHistoryItems = (items: BrowsingHistoryRecord[]): void => {
-  items.forEach(item => {
-    const historyItem = document.createElement('div');
-    historyItem.className = 'history-item';
+function filterByTimeRange(entries: BrowsingHistoryRecord[]): BrowsingHistoryRecord[] {
+  if (currentTimeRange === 'all') return entries;
+  const now = Date.now();
+  if (currentTimeRange === 'today') {
+    const todayStart = new Date().setHours(0, 0, 0, 0);
+    return entries.filter(e => new Date(e.createdDate).getTime() >= todayStart);
+  }
+  if (currentTimeRange === 'week') {
+    return entries.filter(e => new Date(e.createdDate).getTime() >= now - 7 * 86400000);
+  }
+  return entries;
+}
 
-    historyItem.innerHTML = `
-      <div class="history-time">${FormatUtils.getFriendlyDateString(item.createdDate)}</div>
-      <div><img src="${item.faviconUrl}" alt="" class="history-favicon" onerror="this.src='data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌐</text></svg>'"></div>
-      <div class="history-content">
-        <div class="history-title" title="${item.title}">${item.title}</div>
-        <div class="history-domain">${item.topLevelDomain}</div>
-      </div>
-      <div>
-        <button class="delete-button btn-icon" data-id="${item.id}">
-          <i data-lucide="x" width="14" height="14"></i>
-        </button>
-      </div>
-    `;
+// --- Rendering ---
+function renderAll(): void {
+  renderHistoryList();
+  renderSparkline();
+  renderDomainChart();
+  updateStats();
+  updateSelectionUI();
 
-    historyItem.querySelector('.delete-button')?.addEventListener('click', async (e: Event) => {
-      e.stopPropagation();
-      await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, item.id);
-      historyItem.remove();
-      allLoadedItems.splice(allLoadedItems.indexOf(item), 1);
-      if (allLoadedItems.length === 0) {
-        document.getElementById('no-history').style.display = 'block';
-        document.getElementById('delete-all').style.display = 'none';
+  const hasEntries = allEntries.length > 0;
+  noHistory.style.display = hasEntries ? 'none' : 'block';
+  deleteAllBtn.style.display = hasEntries ? 'block' : 'none';
+}
+
+function updateStats(): void {
+  const totalDomains = new Set(allEntries.map(e => e.topLevelDomain)).size;
+  const totalActive = allEntries.reduce((a, e) => a + (e.activeDuration || 0), 0);
+  statsLabel.textContent = `${allEntries.length.toLocaleString()} pages \u00b7 ${totalDomains} sites \u00b7 ${FormatUtils.formatDuration(totalActive)} active`;
+}
+
+function updateSelectionUI(): void {
+  if (selectedIds.size > 0) {
+    deleteSelectedBtn.style.display = 'inline-flex';
+    deleteSelectedCount.textContent = `delete ${selectedIds.size} selected`;
+  } else {
+    deleteSelectedBtn.style.display = 'none';
+  }
+}
+
+async function deleteSelected(): Promise<void> {
+  const ids = Array.from(selectedIds);
+  for (const id of ids) {
+    await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, id);
+  }
+  allEntries = allEntries.filter(e => !selectedIds.has(e.id));
+  selectedIds.clear();
+  renderAll();
+}
+
+// --- Session grouping ---
+interface Session { entries: BrowsingHistoryRecord[] }
+interface DateGroup { label: string; dateKey: string; sessions: Session[] }
+
+function groupIntoSessions(entries: BrowsingHistoryRecord[]): DateGroup[] {
+  if (entries.length === 0) return [];
+
+  // Group by date first
+  const dateMap = new Map<string, BrowsingHistoryRecord[]>();
+  for (const entry of entries) {
+    const d = new Date(entry.createdDate);
+    const key = d.toDateString();
+    if (!dateMap.has(key)) dateMap.set(key, []);
+    dateMap.get(key)!.push(entry);
+  }
+
+  const dateGroups: DateGroup[] = [];
+  for (const [dateKey, dayEntries] of dateMap) {
+    // Sort descending within day
+    dayEntries.sort((a, b) => new Date(b.createdDate).getTime() - new Date(a.createdDate).getTime());
+
+    // Group into sessions by 30-min gap
+    const sessions: Session[] = [];
+    let currentSession: BrowsingHistoryRecord[] = [dayEntries[0]];
+
+    for (let i = 1; i < dayEntries.length; i++) {
+      const gap = new Date(dayEntries[i - 1].createdDate).getTime() - new Date(dayEntries[i].createdDate).getTime();
+      if (gap > SESSION_GAP_MS) {
+        sessions.push({ entries: currentSession });
+        currentSession = [dayEntries[i]];
+      } else {
+        currentSession.push(dayEntries[i]);
       }
-    });
+    }
+    if (currentSession.length) sessions.push({ entries: currentSession });
 
-    historyItem.querySelector('.history-content')?.addEventListener('click', async (e: Event) => {
-      e.stopPropagation();
-      await window.BrowserAPI.createTab(window.BrowserAPI.appWindowId, item.url, true);
+    dateGroups.push({
+      label: FormatUtils.getRelativeDayLabel(new Date(dayEntries[0].createdDate)),
+      dateKey,
+      sessions,
     });
+  }
 
-    historyListElement.appendChild(historyItem);
-  });
+  return dateGroups;
+}
+
+function renderHistoryList(): void {
+  historyList.innerHTML = '';
+  const dateGroups = groupIntoSessions(allEntries);
+
+  for (const dg of dateGroups) {
+    // Date label
+    const dateLabel = document.createElement('div');
+    dateLabel.className = 'date-group-label';
+    dateLabel.textContent = dg.label;
+    historyList.appendChild(dateLabel);
+
+    // Sessions
+    for (const session of dg.sessions) {
+      renderSession(session, historyList);
+    }
+  }
 
   createIcons({ icons });
-};
+}
 
-const showLoadingIndicator = (): void => {
-  const loader = document.createElement('div');
-  loader.id = 'loading-indicator';
-  loader.className = 'loading-indicator';
-  loader.textContent = 'Loading...';
-  historyListElement.appendChild(loader);
-};
+function renderSession(session: Session, container: HTMLElement): void {
+  const wrapper = document.createElement('div');
+  wrapper.style.marginBottom = '2px';
 
-const removeLoadingIndicator = (): void => {
-  document.getElementById('loading-indicator')?.remove();
-};
+  const lastEntry = session.entries[session.entries.length - 1];
+  const sessionActive = session.entries.reduce((a, e) => a + (e.activeDuration || 0), 0);
+  const uniqueDomains = [...new Set(session.entries.map(e => e.topLevelDomain))];
+
+  // Session header
+  const header = document.createElement('div');
+  header.className = 'session-header';
+  let expanded = true;
+
+  const startTime = new Date(lastEntry.createdDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  // Build domain badges HTML
+  const domainBadgesHtml = uniqueDomains.slice(0, 6).map(domain => {
+    const faviconUrl = `https://${domain}/favicon.ico`;
+    return `<span class="session-domain-badge"><img src="${faviconUrl}" onerror="this.parentElement.innerHTML='&#x1F310;'" width="16" height="16"></span>`;
+  }).join('');
+  const moreHtml = uniqueDomains.length > 6 ? `<span class="session-domain-more">+${uniqueDomains.length - 6}</span>` : '';
+
+  header.innerHTML = `
+    <span class="session-expand-icon expanded">\u25B6</span>
+    <span class="session-time">${startTime}</span>
+    <span class="session-dash">\u2014</span>
+    <span class="session-meta">${session.entries.length} pages \u00b7 ${FormatUtils.formatDuration(sessionActive)} active</span>
+    <div class="session-domains">${domainBadgesHtml}${moreHtml}</div>
+    <button class="session-delete-btn" title="delete session">\u2715</button>
+  `;
+
+  const entriesDiv = document.createElement('div');
+  entriesDiv.className = 'session-entries';
+
+  header.addEventListener('click', (e) => {
+    if ((e.target as HTMLElement).classList.contains('session-delete-btn')) return;
+    expanded = !expanded;
+    entriesDiv.style.display = expanded ? 'block' : 'none';
+    header.querySelector('.session-expand-icon')!.classList.toggle('expanded', expanded);
+  });
+
+  header.querySelector('.session-delete-btn')?.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    for (const entry of session.entries) {
+      await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, entry.id);
+    }
+    const ids = new Set(session.entries.map(e => e.id));
+    allEntries = allEntries.filter(e => !ids.has(e.id));
+    ids.forEach(id => selectedIds.delete(id));
+    wrapper.remove();
+    renderSparkline();
+    renderDomainChart();
+    updateStats();
+    updateSelectionUI();
+    if (allEntries.length === 0) {
+      noHistory.style.display = 'block';
+      deleteAllBtn.style.display = 'none';
+    }
+  });
+
+  // Render entries
+  for (const entry of session.entries) {
+    entriesDiv.appendChild(renderEntry(entry));
+  }
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(entriesDiv);
+  container.appendChild(wrapper);
+}
+
+function renderEntry(entry: BrowsingHistoryRecord): HTMLElement {
+  const row = document.createElement('div');
+  row.className = 'history-entry';
+
+  const time = new Date(entry.createdDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const faviconUrl = entry.faviconUrl || `https://${entry.topLevelDomain}/favicon.ico`;
+
+  row.innerHTML = `
+    <input type="checkbox" ${selectedIds.has(entry.id) ? 'checked' : ''} />
+    <span class="entry-time">${time}</span>
+    <span class="entry-favicon"><img src="${faviconUrl}" width="14" height="14" onerror="this.parentElement.innerHTML='<span class=\\'entry-favicon-fallback\\'>&#x1F310;</span>'"></span>
+    <span class="entry-title" title="${escapeHtml(entry.title)}">${escapeHtml(entry.title)}</span>
+    <span class="entry-domain">${escapeHtml(entry.topLevelDomain)}</span>
+    <div class="entry-duration">
+      <span class="entry-active-dur" title="active time">${FormatUtils.formatDuration(entry.activeDuration || 0)}</span>
+      <span class="entry-total-dur" title="total time">${FormatUtils.formatDuration(entry.totalDuration || 0)}</span>
+    </div>
+    <button class="entry-delete-btn"><i data-lucide="x" width="12" height="12"></i></button>
+  `;
+
+  row.querySelector('input[type="checkbox"]')?.addEventListener('change', () => {
+    if (selectedIds.has(entry.id)) selectedIds.delete(entry.id);
+    else selectedIds.add(entry.id);
+    updateSelectionUI();
+  });
+
+  row.querySelector('.entry-title')?.addEventListener('click', () => {
+    window.BrowserAPI.createTab(window.BrowserAPI.appWindowId, entry.url, true);
+  });
+
+  row.querySelector('.entry-delete-btn')?.addEventListener('click', async (e) => {
+    e.stopPropagation();
+    await window.BrowserAPI.removeBrowsingHistory(window.BrowserAPI.appWindowId, entry.id);
+    allEntries = allEntries.filter(item => item.id !== entry.id);
+    selectedIds.delete(entry.id);
+    row.remove();
+    renderSparkline();
+    renderDomainChart();
+    updateStats();
+    updateSelectionUI();
+    if (allEntries.length === 0) {
+      noHistory.style.display = 'block';
+      deleteAllBtn.style.display = 'none';
+    }
+  });
+
+  return row;
+}
+
+// --- Heatmap ---
+function renderHeatmap(stats: Array<{ date: string; count: number; activeDuration: number }>): void {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const currentDow = todayStart.getDay();
+  const startDate = new Date(todayStart);
+  startDate.setDate(startDate.getDate() - (52 * 7 + currentDow));
+
+  // Build day map from stats
+  const dayMap = new Map<string, { count: number; active: number }>();
+  for (const s of stats) {
+    dayMap.set(s.date, { count: s.count, active: s.activeDuration });
+  }
+
+  // Build weeks
+  type DayCell = { date: Date; dow: number; count: number; active: number; label: string };
+  const weeks: DayCell[][] = [];
+  let currentWeek: DayCell[] = [];
+  let maxCount = 0;
+  let totalActive = 0;
+  let totalPages = 0;
+  let activeDays = 0;
+
+  interface MonthLabel { month: string; weekIndex: number }
+  const monthLabels: MonthLabel[] = [];
+  let lastMonth = -1;
+
+  const cursor = new Date(startDate);
+  while (cursor <= todayStart) {
+    const dateStr = cursor.toISOString().split('T')[0];
+    const data = dayMap.get(dateStr) || { count: 0, active: 0 };
+    if (data.count > maxCount) maxCount = data.count;
+    totalActive += data.active;
+    totalPages += data.count;
+    if (data.count > 0) activeDays++;
+
+    const m = cursor.getMonth();
+    if (m !== lastMonth) {
+      monthLabels.push({
+        month: cursor.toLocaleDateString([], { month: 'short' }).toLowerCase(),
+        weekIndex: weeks.length,
+      });
+      lastMonth = m;
+    }
+
+    currentWeek.push({
+      date: new Date(cursor),
+      dow: cursor.getDay(),
+      count: data.count,
+      active: data.active,
+      label: cursor.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' }).toLowerCase(),
+    });
+
+    if (cursor.getDay() === 6 || cursor.getTime() === todayStart.getTime()) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  if (currentWeek.length) weeks.push(currentWeek);
+
+  const cellSize = 11;
+  const cellGap = 2;
+  const dayLabelW = 24;
+  const topPad = 18;
+  const gridW = weeks.length * (cellSize + cellGap);
+  const gridH = 7 * (cellSize + cellGap);
+  const dayLabels = ['', 'mon', '', 'wed', '', 'fri', ''];
+
+  function getLevel(count: number): number {
+    if (count === 0) return 0;
+    const ratio = count / maxCount;
+    if (ratio <= 0.25) return 1;
+    if (ratio <= 0.5) return 2;
+    if (ratio <= 0.75) return 3;
+    return 4;
+  }
+
+  // Build HTML
+  let svgContent = '';
+
+  // Month labels
+  for (const m of monthLabels) {
+    svgContent += `<text x="${dayLabelW + m.weekIndex * (cellSize + cellGap)}" y="12" font-size="9" fill="var(--text-secondary)">${m.month}</text>`;
+  }
+
+  // Day labels
+  for (let i = 0; i < dayLabels.length; i++) {
+    if (dayLabels[i]) {
+      svgContent += `<text x="0" y="${topPad + i * (cellSize + cellGap) + cellSize - 1}" font-size="8" fill="var(--text-secondary)">${dayLabels[i]}</text>`;
+    }
+  }
+
+  // Cells
+  for (let wi = 0; wi < weeks.length; wi++) {
+    for (const day of weeks[wi]) {
+      const level = getLevel(day.count);
+      const isToday = day.date.toDateString() === now.toDateString();
+      const x = dayLabelW + wi * (cellSize + cellGap);
+      const y = topPad + day.dow * (cellSize + cellGap);
+      svgContent += `<rect class="heatmap-cell" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" fill="${HEATMAP_LEVELS[level]}" ${isToday ? `stroke="var(--primary-color)" stroke-width="1.5"` : ''} data-label="${day.label}" data-count="${day.count}" data-active="${day.active}" />`;
+    }
+  }
+
+  const svgW = dayLabelW + gridW + 8;
+  const svgH = topPad + gridH + 4;
+
+  heatmapContainer.innerHTML = `
+    <div class="heatmap-header">
+      <span class="heatmap-summary">${totalPages.toLocaleString()} pages visited in the last year</span>
+      <div class="heatmap-stats">
+        <span><span class="stat-value">${activeDays}</span> active days</span>
+        <span><span class="stat-value">${FormatUtils.formatDuration(totalActive)}</span> active time</span>
+      </div>
+    </div>
+    <div style="position:relative;overflow-x:auto;overflow-y:visible;">
+      <svg width="${svgW}" height="${svgH}" style="display:block;">${svgContent}</svg>
+      <div class="heatmap-legend">
+        <span class="heatmap-legend-label">less</span>
+        ${HEATMAP_LEVELS.map(c => `<div class="heatmap-legend-cell" style="background:${c}"></div>`).join('')}
+        <span class="heatmap-legend-label" style="margin-left:4px">more</span>
+      </div>
+    </div>
+  `;
+
+  // Tooltip behavior
+  const svgEl = heatmapContainer.querySelector('svg')!;
+  const tooltipContainer = heatmapContainer.querySelector('div[style*="position:relative"]') as HTMLElement;
+  let tooltip: HTMLElement | null = null;
+
+  svgEl.addEventListener('mouseover', (e) => {
+    const target = e.target as SVGElement;
+    if (!target.classList.contains('heatmap-cell')) return;
+    const label = target.getAttribute('data-label') || '';
+    const count = parseInt(target.getAttribute('data-count') || '0');
+    const active = parseInt(target.getAttribute('data-active') || '0');
+    const rect = target.getBoundingClientRect();
+    const cr = tooltipContainer.getBoundingClientRect();
+
+    if (!tooltip) {
+      tooltip = document.createElement('div');
+      tooltip.className = 'heatmap-tooltip';
+      tooltipContainer.appendChild(tooltip);
+    }
+    tooltip.innerHTML = `<div class="heatmap-tooltip-title">${label}</div><div class="heatmap-tooltip-sub">${count === 0 ? 'no activity' : `${count} pages \u00b7 ${FormatUtils.formatDuration(active)} active`}</div>`;
+    tooltip.style.left = `${rect.left - cr.left + cellSize / 2}px`;
+    tooltip.style.top = `${rect.top - cr.top - 4}px`;
+    tooltip.style.display = 'block';
+  });
+
+  svgEl.addEventListener('mouseout', (e) => {
+    const target = e.target as SVGElement;
+    if (target.classList.contains('heatmap-cell') && tooltip) {
+      tooltip.style.display = 'none';
+    }
+  });
+}
+
+// --- Sparkline ---
+function renderSparkline(): void {
+  // Compute daily page counts for last 14 days
+  const dailyData: { date: Date; count: number; active: number; label: string }[] = [];
+  for (let i = 13; i >= 0; i--) {
+    const d = new Date(Date.now() - i * 86400000);
+    const dayStart = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    const dayEnd = dayStart + 86400000;
+    let count = 0;
+    let active = 0;
+    for (const e of allEntries) {
+      const ts = new Date(e.createdDate).getTime();
+      if (ts >= dayStart && ts < dayEnd) {
+        count++;
+        active += e.activeDuration || 0;
+      }
+    }
+    const label = i === 0 ? 'today' : i === 1 ? 'yday' : d.toLocaleDateString([], { month: 'short', day: 'numeric' }).toLowerCase();
+    dailyData.push({ date: d, count, active, label });
+  }
+
+  const maxActive = Math.max(...dailyData.map(d => d.active), 1);
+  const w = 280, h = 48;
+
+  const points = dailyData.map((d, i) => ({
+    x: (i / (dailyData.length - 1)) * w,
+    y: h - (d.active / maxActive) * (h - 8) - 4,
+    ...d,
+  }));
+
+  // Build smooth curve
+  let pathD = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const p = points[i];
+    const cpx = (prev.x + p.x) / 2;
+    pathD += ` C ${cpx} ${prev.y}, ${cpx} ${p.y}, ${p.x} ${p.y}`;
+  }
+
+  let dotsAndLabels = '';
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    dotsAndLabels += `<circle cx="${p.x}" cy="${p.y}" r="2.5" fill="var(--bg-light)" stroke="var(--primary-color)" stroke-width="1.5" />`;
+    if (i === 0 || i === points.length - 1 || i === 7) {
+      dotsAndLabels += `<text x="${p.x}" y="${h + 14}" text-anchor="middle" font-size="8" fill="var(--text-secondary)">${p.label}</text>`;
+    }
+  }
+
+  sparklineContainer.innerHTML = `
+    <svg class="sparkline-svg" width="${w}" height="${h + 16}" viewBox="0 0 ${w} ${h + 16}" style="overflow:visible">
+      <defs>
+        <linearGradient id="spark-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stop-color="var(--primary-color)" stop-opacity="0.1" />
+          <stop offset="100%" stop-color="var(--primary-color)" stop-opacity="0" />
+        </linearGradient>
+      </defs>
+      <path d="${pathD} L ${w} ${h + 4} L 0 ${h + 4} Z" fill="url(#spark-fill)" />
+      <path d="${pathD}" fill="none" stroke="var(--primary-color)" stroke-width="1.5" />
+      ${dotsAndLabels}
+    </svg>
+  `;
+}
+
+// --- Domain Chart ---
+function renderDomainChart(): void {
+  // Aggregate by domain
+  const map = new Map<string, { domain: string; visits: number; active: number; faviconUrl: string }>();
+  for (const e of allEntries) {
+    const existing = map.get(e.topLevelDomain);
+    if (existing) {
+      existing.visits++;
+      existing.active += e.activeDuration || 0;
+    } else {
+      map.set(e.topLevelDomain, {
+        domain: e.topLevelDomain,
+        visits: 1,
+        active: e.activeDuration || 0,
+        faviconUrl: e.faviconUrl || `https://${e.topLevelDomain}/favicon.ico`,
+      });
+    }
+  }
+
+  const sorted = Array.from(map.values())
+    .sort((a, b) => b.active - a.active)
+    .slice(0, 8);
+
+  const maxActive = Math.max(...sorted.map(d => d.active), 1);
+
+  domainChartContainer.innerHTML = sorted.map(d => `
+    <div class="domain-row">
+      <span class="domain-favicon"><img src="${d.faviconUrl}" width="14" height="14" onerror="this.parentElement.className='domain-favicon-fallback';this.parentElement.innerHTML='&#x1F310;'"></span>
+      <span class="domain-name">${escapeHtml(d.domain)}</span>
+      <div class="domain-bar-track">
+        <div class="domain-bar-fill" style="width:${(d.active / maxActive) * 100}%"></div>
+      </div>
+      <span class="domain-duration">${FormatUtils.formatDuration(d.active)}</span>
+    </div>
+  `).join('');
+}
+
+// --- Helpers ---
+function escapeHtml(str: string): string {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}

--- a/src/types/browsing-history-record.ts
+++ b/src/types/browsing-history-record.ts
@@ -4,5 +4,8 @@ export type BrowsingHistoryRecord = {
   url: string,
   title: string,
   topLevelDomain: string,
-  faviconUrl?: string
+  faviconUrl?: string,
+  totalDuration: number,
+  activeDuration: number,
+  outTimestamp?: Date
 }


### PR DESCRIPTION
## Summary
This PR significantly enhances the browsing history page with analytics visualizations, session-based grouping, and time tracking. The history view now displays activity heatmaps, sparklines, domain/category charts, and organizes entries into browsing sessions separated by idle time.

## Key Changes

### Frontend (History Page)
- **Session Grouping**: Entries are now grouped by date and further organized into sessions based on a 30-minute idle gap threshold
- **Analytics Dashboard**: Added three new visualization cards:
  - Activity sparkline (14-day trend)
  - Top sites bar chart with duration metrics
  - Category distribution pie chart (dev, social, media, news, etc.)
- **Heatmap Visualization**: Year-long contribution graph showing daily activity with color-coded intensity levels and responsive SVG rendering
- **Enhanced UI**: 
  - Time range filters (All/Today/Week)
  - Improved search with clear button
  - Session headers showing time, page count, active duration, and domain badges
  - Expandable/collapsible sessions
  - Per-entry active/total duration display
- **Pagination**: Switched from scroll-based to IntersectionObserver for more efficient infinite scroll
- **Styling**: Complete CSS redesign with card-based layout, improved spacing, and better visual hierarchy

### Backend (Time Tracking)
- **Tab Time Tracking**: Added active time accumulation per tab with periodic flushing to prevent data loss on crashes
  - `pageStartTime`: Tracks when a page was loaded
  - `activeTimeAccumulator`: Accumulates active time in seconds
  - `lastActiveStart`: Tracks when the tab became active
  - `startTimeFlush()` / `stopTimeFlush()`: Periodic persistence every 15 minutes
  - `pauseActiveTime()` / `resumeActiveTime()`: Called when tab loses/gains focus
  - `finalizePageTime()`: Persists accumulated time when navigating away

### Database
- **Schema Updates**: Added `totalDuration` and `activeDuration` fields to browsing history records
- **Stats API**: New `fetchHistoryStats()` method returns daily aggregated data (page count, active duration) for heatmap rendering

### Utilities
- **FormatUtils**: Added `formatDuration()` for human-readable time display (e.g., "2h 15m") and `getRelativeDayLabel()` for relative date labels

### Domain Categorization
- Comprehensive domain-to-category mapping (50+ domains) covering dev, social, media, news, search, productivity, shopping, reference, and design categories
- Automatic category detection with suffix matching for subdomains

## Notable Implementation Details
- Heatmap uses responsive SVG with viewBox for proper scaling across devices
- Month labels on heatmap skip rendering if too close together to avoid overlap
- Session expansion state is tracked per session with visual indicator rotation
- Time tracking uses floor division to store whole seconds and avoid floating-point precision issues
- Analytics update reactively when entries are deleted
- Page size increased from 50 to 100 entries for better pagination efficiency

https://claude.ai/code/session_014DwJwTwVAQd4AojrSed8n5