### PR TITLE
Store one row per visit in browsing history

### DIFF
--- a/src/main/browser/bookmark-manager.ts
+++ b/src/main/browser/bookmark-manager.ts
@@ -61,11 +61,12 @@ export abstract class BookmarkManager {
 
     const stmt = db.prepare(`
       SELECT b.*,
-        COALESCE(h.visitCount, 0) as visits,
-        h.createdDate as lastVisited
+        COUNT(h.id) as visits,
+        MAX(h.createdDate) as lastVisited
       FROM bookmark b
       LEFT JOIN browsingHistory h ON b.url = h.url
       WHERE b.type = ? AND (b.url LIKE ? OR b.title LIKE ?)
+      GROUP BY b.id
       ORDER BY ${orderBy}
       LIMIT ? OFFSET ?;
     `);

--- a/src/main/browser/browsing-history-manager.ts
+++ b/src/main/browser/browsing-history-manager.ts
@@ -42,42 +42,19 @@ export abstract class BrowsingHistoryManager {
     return records;
   }
 
-  public static async addRecord(appWindowId: string, url: string, title: string, topLevelDomain: string, faviconUrl: string): Promise<BrowsingHistoryRecord | null>{
-    const db = BrowsingHistoryManager.getDb(appWindowId);
-    if (!db) return null;
-    const stmt = db.prepare("INSERT INTO browsingHistory (id, url, title, createdDate, topLevelDomain, faviconUrl) VALUES (?, ?, ?, ?, ?, ?);");
-    const id = uuid();
-    const result = await stmt.run(id, url, title, new Date().toISOString(), topLevelDomain, faviconUrl);
-    const newlyCreatedRecord: BrowsingHistoryRecord = { id: id, url, title, createdDate: new Date(), topLevelDomain, faviconUrl, totalDuration: 0, activeDuration: 0 };
-    return newlyCreatedRecord;
-  }
-
   /**
-   * Atomically finds an existing record by URL and updates its timestamp,
-   * or inserts a new record if none exists. Uses a synchronous transaction
-   * to prevent duplicate entries from concurrent async calls.
+   * Inserts a new history record for a single visit. One row per visit —
+   * revisiting the same URL always creates a new row so the history
+   * timeline and per-visit time tracking are preserved.
    */
-  public static upsertRecord(appWindowId: string, url: string, title: string, topLevelDomain: string, faviconUrl: string): BrowsingHistoryRecord | null {
+  public static insertRecord(appWindowId: string, url: string, title: string, topLevelDomain: string, faviconUrl: string): BrowsingHistoryRecord | null {
     const db = BrowsingHistoryManager.getDb(appWindowId);
     if (!db) return null;
-
-    const findStmt = db.prepare("SELECT * FROM browsingHistory WHERE url = ? ORDER BY createdDate DESC LIMIT 1;");
-    const updateStmt = db.prepare("UPDATE browsingHistory SET createdDate = ?, visitCount = COALESCE(visitCount, 0) + 1 WHERE id = ?;");
-    const insertStmt = db.prepare("INSERT INTO browsingHistory (id, url, title, createdDate, topLevelDomain, faviconUrl, visitCount) VALUES (?, ?, ?, ?, ?, ?, 1);");
-
-    const upsert = db.transaction((url: string, title: string, topLevelDomain: string, faviconUrl: string) => {
-      const existing = findStmt.get(url) as BrowsingHistoryRecord | undefined;
-      const now = new Date().toISOString();
-      if (existing) {
-        updateStmt.run(now, existing.id);
-        return { ...existing, createdDate: new Date(now) } as BrowsingHistoryRecord;
-      }
-      const id = uuid();
-      insertStmt.run(id, url, title, now, topLevelDomain, faviconUrl);
-      return { id, url, title, createdDate: new Date(now), topLevelDomain, faviconUrl, totalDuration: 0, activeDuration: 0 } as BrowsingHistoryRecord;
-    });
-
-    return upsert(url, title, topLevelDomain, faviconUrl);
+    const id = uuid();
+    const createdDate = new Date();
+    const stmt = db.prepare("INSERT INTO browsingHistory (id, url, title, createdDate, topLevelDomain, faviconUrl) VALUES (?, ?, ?, ?, ?, ?);");
+    stmt.run(id, url, title, createdDate.toISOString(), topLevelDomain, faviconUrl);
+    return { id, url, title, createdDate, topLevelDomain, faviconUrl, totalDuration: 0, activeDuration: 0 };
   }
 
   public static async updateRecordTitle(appWindowId: string, recordId: string, title: string): Promise<void>{
@@ -92,21 +69,6 @@ export abstract class BrowsingHistoryManager {
     if (!db) return;
     const stmt = db.prepare("UPDATE browsingHistory SET faviconUrl = ? WHERE id = ?;");
     await stmt.run(faviconUrl, recordId);
-  }
-
-  public static async findLastRecordByUrl(appWindowId: string, url: string): Promise<BrowsingHistoryRecord | null>{
-    const db = BrowsingHistoryManager.getDb(appWindowId);
-    if (!db) return null;
-    const stmt = db.prepare("SELECT * FROM browsingHistory WHERE url = ? ORDER BY createdDate DESC LIMIT 1;");
-    const record = stmt.get(url) as BrowsingHistoryRecord | undefined;
-    return record || null;
-  }
-
-  public static async updateRecordTimestamp(appWindowId: string, recordId: string): Promise<void>{
-    const db = BrowsingHistoryManager.getDb(appWindowId);
-    if (!db) return;
-    const stmt = db.prepare("UPDATE browsingHistory SET createdDate = ? WHERE id = ?;");
-    await stmt.run(new Date().toISOString(), recordId);
   }
 
   public static async removeRecord(appWindowId: string, recordId: string): Promise<boolean>{

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -792,13 +792,14 @@ export class Tab {
       } catch (error) {
         //do nothing
       }
-      // Strip URL fragment/hash to avoid duplicate history entries for the same page
-      // (e.g. page.html#section1 vs page.html#section2 should be one record)
+      // Strip URL fragment/hash so in-page anchor changes don't create a
+      // brand new history entry (e.g. page.html#section1 vs page.html#section2
+      // are the same visit).
       const urlWithoutFragment = url.split('#')[0];
-      // Atomic upsert: finds existing record by URL and updates timestamp,
-      // or inserts a new record — all within a single synchronous transaction
-      // to prevent duplicate entries from concurrent calls.
-      const record = BrowsingHistoryManager.upsertRecord(
+      // One row per visit — revisits to the same URL intentionally create
+      // new rows so the history timeline and per-visit time tracking are
+      // preserved.
+      const record = BrowsingHistoryManager.insertRecord(
         this.parentAppWindow.id, urlWithoutFragment, this.title,
         urlObject ? urlObject.hostname : '',
         urlObject ? `${urlObject.protocol}//${urlObject.hostname}/favicon.ico` : ''

--- a/src/main/database/schema/browsing-history-schema.ts
+++ b/src/main/database/schema/browsing-history-schema.ts
@@ -48,11 +48,6 @@ export const BrowsingHistorySchema: TableSchema = {
       name: 'outTimestamp',
       columnType: { type: 'timestamp' }
       // Nullable — set when user navigates away or closes tab
-      },
-    {
-      name: 'visitCount',
-      columnType: { type: 'standard', sqlType: 'INTEGER' },
-      defaultValue: 1,
     }
   ],
   indices: [


### PR DESCRIPTION
The history table was storing one row per unique URL with a visitCount
column that got incremented on each revisit. This collapsed the history
timeline so the history page's session grouping, per-visit durations,
and "pages visited" totals were all wrong, and it made the bookmark
stat a separate number from the history page.

Switch to one row per visit (plain INSERT, no upsert), drop the
visitCount column from the schema, and compute the bookmarks "visits"
stat from COUNT(*) of history rows for that URL via LEFT JOIN +
GROUP BY. The existing idxBrowsingHistoryUrl index supports the query.

https://claude.ai/code/session_0147T5tG7aAwGMbQDw2WG3Zk