### PR TITLE
Remove heat bar visualization and visits-based sorting

### DIFF
--- a/src/main/browser/bookmark-manager.ts
+++ b/src/main/browser/bookmark-manager.ts
@@ -57,7 +57,7 @@ export abstract class BookmarkManager {
     const db = BookmarkManager.getDb(appWindowId);
     if (!db) return [];
 
-    const orderBy = type === 'queue' ? 'b.createdDate DESC' : 'visits DESC, b.createdDate DESC';
+    const orderBy = 'b.createdDate DESC';
 
     const stmt = db.prepare(`
       SELECT b.*,

--- a/src/renderer/pages/bookmarks/index.css
+++ b/src/renderer/pages/bookmarks/index.css
@@ -426,17 +426,6 @@
   opacity: 1;
 }
 
-/* Heat bar — thin gradient at bottom of reference rows */
-.bookmark-heat-bar {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  height: 2px;
-  background: linear-gradient(90deg, #c7d2fe, #6366f1);
-  border-radius: 1px;
-  transition: width var(--transition-medium) ease;
-}
-
 /* --------------------------------------------------------------------------
    Clear All Footer
    -------------------------------------------------------------------------- */

--- a/src/renderer/pages/bookmarks/index.ts
+++ b/src/renderer/pages/bookmarks/index.ts
@@ -92,7 +92,6 @@ let currentOffset = 0;
 let isLoading = false;
 let hasMore = true;
 let allLoadedItems: BookmarkWithStats[] = [];
-let maxVisits = 1;
 
 // --- DOM refs ---
 
@@ -219,10 +218,6 @@ async function loadBookmarks(): Promise<void> {
   allLoadedItems = allLoadedItems.concat(filtered);
   currentOffset += items.length;
 
-  for (const item of allLoadedItems) {
-    if (item.visits > maxVisits) maxVisits = item.visits;
-  }
-
   updateVisibility();
   renderBookmarkItems(filtered);
   isLoading = false;
@@ -308,14 +303,6 @@ function renderBookmarkItems(items: BookmarkWithStats[]): void {
       ? `<span class="bookmark-visits" style="color: ${heatColor(item.visits)}">${item.visits} visits</span>`
       : '';
 
-    // Heat bar (reference only)
-    const heatWidth = item.type === 'reference'
-      ? Math.max(4, (item.visits / maxVisits) * 100)
-      : 0;
-    const heatBarHtml = item.type === 'reference'
-      ? `<div class="bookmark-heat-bar" style="width: ${heatWidth}%"></div>`
-      : '';
-
     // Move tooltip
     const moveTitle = item.type === 'queue' ? 'Move to Reference' : 'Move to Queue';
     const moveIcon = item.type === 'queue' ? 'archive' : 'book-open';
@@ -340,7 +327,6 @@ function renderBookmarkItems(items: BookmarkWithStats[]): void {
           <i data-lucide="x" width="12" height="12"></i>
         </button>
       </div>
-      ${heatBarHtml}
     `;
 
     // Click content → open


### PR DESCRIPTION
## Summary
This PR removes the heat bar visualization feature and simplifies bookmark sorting by removing visits-based ordering logic.

## Key Changes
- **Removed heat bar UI component**: Deleted the visual heat bar that appeared at the bottom of reference bookmark rows, including its CSS styling and HTML rendering logic
- **Removed visit tracking for visualization**: Eliminated the `maxVisits` variable that was used to calculate relative heat bar widths
- **Simplified bookmark sorting**: Changed the ordering logic to use creation date descending for all bookmark types, removing the previous distinction where reference bookmarks were sorted by visit count

## Implementation Details
- Removed `maxVisits` state variable and the loop that calculated it during bookmark loading
- Removed heat bar width calculation and rendering from `renderBookmarkItems()`
- Removed `.bookmark-heat-bar` CSS class and its gradient styling
- Updated the SQL query ordering to use `'b.createdDate DESC'` uniformly instead of conditional visit-based sorting for reference types

https://claude.ai/code/session_01GHA1zK1VrkS7rLmiNgfft9