### PR TITLE
Add Chrome on Linux user agent preset and set Chrome as default

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -189,7 +189,7 @@ export abstract class SettingsEnforcer {
     const browsingSes = session.fromPartition('persist:browsertabs');
     const privateSes = session.fromPartition('persist:private');
 
-    const preset = settings.userAgentPreset || (process.platform === 'darwin' ? 'firefox-mac' : process.platform === 'linux' ? 'firefox-linux' : 'firefox-windows');
+    const preset = settings.userAgentPreset || (process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows');
 
     let userAgent: string;
 
@@ -201,8 +201,9 @@ export abstract class SettingsEnforcer {
       if (!userAgent) return;
     }
 
-    browsingSes.setUserAgent(userAgent);
-    privateSes.setUserAgent(userAgent);
+    const acceptLanguages = 'en-US,en;q=0.9';
+    browsingSes.setUserAgent(userAgent, acceptLanguages);
+    privateSes.setUserAgent(userAgent, acceptLanguages);
 
     // Apply to all existing open tabs so the change takes effect immediately
     for (const wc of webContents.getAllWebContents()) {

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -341,11 +341,12 @@
           <label class="setting-label">User Agent</label>
           <p class="setting-description">Controls how this browser identifies itself to websites. Some sites may serve different content based on the browser identity.</p>
           <select id="user-agent-select" class="form-select">
+            <option value="chrome-windows">Chrome on Windows</option>
+            <option value="chrome-mac">Chrome on macOS</option>
+            <option value="chrome-linux">Chrome on Linux</option>
             <option value="firefox-windows">Firefox on Windows</option>
             <option value="firefox-mac">Firefox on macOS</option>
             <option value="firefox-linux">Firefox on Linux</option>
-            <option value="chrome-windows">Chrome on Windows</option>
-            <option value="chrome-mac">Chrome on macOS</option>
             <option value="safari-mac">Safari on macOS</option>
             <option value="edge-windows">Edge on Windows</option>
             <option value="custom">Custom...</option>

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -664,7 +664,7 @@ function initUserAgentSettings() {
   const preview = document.getElementById('ua-preview');
 
   // Set initial values
-  const defaultPreset = process.platform === 'darwin' ? 'firefox-mac' : process.platform === 'linux' ? 'firefox-linux' : 'firefox-windows';
+  const defaultPreset = process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows';
   select.value = settings.userAgentPreset || defaultPreset;
   customInput.value = settings.userAgentCustomValue || '';
   customContainer.style.display = select.value === 'custom' ? '' : 'none';

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -75,7 +75,7 @@ export interface BrowserSettings {
   popupBlockedSites: string[];
 
   // User Agent
-  userAgentPreset: 'chrome-windows' | 'chrome-mac' | 'safari-mac' | 'firefox-windows' | 'firefox-mac' | 'firefox-linux' | 'edge-windows' | 'custom';
+  userAgentPreset: 'chrome-windows' | 'chrome-mac' | 'chrome-linux' | 'safari-mac' | 'firefox-windows' | 'firefox-mac' | 'firefox-linux' | 'edge-windows' | 'custom';
   userAgentCustomValue: string;
 
   // Keyboard Shortcuts
@@ -170,6 +170,10 @@ export const USER_AGENT_PRESETS: Record<string, { label: string; value: string }
   'chrome-mac': {
     label: 'Chrome on macOS',
     value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+  },
+  'chrome-linux': {
+    label: 'Chrome on Linux',
+    value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
   },
   'safari-mac': {
     label: 'Safari on macOS',
@@ -268,8 +272,8 @@ export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
   popupAllowedSites: [],
   popupBlockedSites: [],
 
-  // User Agent (Firefox UA matching the user's OS by default)
-  userAgentPreset: typeof process !== 'undefined' && process.platform === 'darwin' ? 'firefox-mac' : typeof process !== 'undefined' && process.platform === 'linux' ? 'firefox-linux' : 'firefox-windows',
+  // User Agent (Chrome UA matching the user's OS by default)
+  userAgentPreset: typeof process !== 'undefined' && process.platform === 'darwin' ? 'chrome-mac' : typeof process !== 'undefined' && process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows',
   userAgentCustomValue: '',
 
   // Keyboard Shortcuts (empty = use defaults)


### PR DESCRIPTION
## Summary
This PR adds support for Chrome on Linux as a user agent preset and changes the default user agent from Firefox to Chrome across all platforms.

## Key Changes
- Added `'chrome-linux'` to the `userAgentPreset` type union in settings types
- Added Chrome on Linux user agent preset with appropriate user agent string for X11/Linux x86_64
- Changed default user agent selection logic to use Chrome presets instead of Firefox:
  - macOS: `chrome-mac` (was `firefox-mac`)
  - Linux: `chrome-linux` (was `firefox-linux`)
  - Windows: `chrome-windows` (was `firefox-windows`)
- Reordered user agent dropdown options to list Chrome presets first, followed by Firefox, then Safari and Edge
- Added `Accept-Language` header (`'en-US,en;q=0.9'`) when setting user agents in both browsing and private sessions
- Updated default preset logic in settings enforcer and renderer to match new Chrome-first defaults

## Implementation Details
- The Chrome on Linux user agent string follows the standard format: `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36`
- All three locations that determine the default preset (settings types, settings enforcer, and renderer) were updated consistently
- The `Accept-Language` header is now explicitly set alongside the user agent to provide a more complete browser identification

https://claude.ai/code/session_01KkMVbBmq8Xm3KWZeR3SNsi