### PR TITLE
Add border styling to inactive tabs

### DIFF
--- a/src/renderer/browser-layout/index.css
+++ b/src/renderer/browser-layout/index.css
@@ -144,6 +144,11 @@ body.platform-darwin:not(.is-fullscreen) .tab-bar {
   margin-right: 0;
 }
 
+.tab:not(.active) {
+  border: 1px solid var(--border-color);
+  border-bottom: none;
+}
+
 .tab:hover {
   background-color: var(--bg-hover);
 }


### PR DESCRIPTION
## Summary
Added visual styling to distinguish inactive tabs by applying a border around them.

## Changes
- Added border styling (1px solid) to inactive tabs using the `--border-color` CSS variable
- Removed the bottom border from inactive tabs to maintain visual consistency with the active tab styling

## Implementation Details
The new `.tab:not(.active)` selector targets all tabs that are not currently active and applies:
- A 1px solid border using the existing `--border-color` CSS variable for consistency with the design system
- Explicitly removes the bottom border (`border-bottom: none`) to create a cleaner visual separation between inactive tabs and the active tab below them

https://claude.ai/code/session_01XfHpWwF38obtmYYAddsL11