### PR TITLE
Reduce tab active time flush interval from 15 to 1 minute

### DIFF
--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -59,7 +59,7 @@ export class Tab {
   private activeTimeAccumulator = 0;
   private lastActiveStart: number | null = null;
   private timeFlushInterval: ReturnType<typeof setInterval> | null = null;
-  private static readonly TIME_FLUSH_INTERVAL_MS = 900_000;
+  private static readonly TIME_FLUSH_INTERVAL_MS = 60_000;
 
   constructor(parentAppWindow: AppWindow, url: string , partitionSetting: string, options?: { suspended?: boolean; title?: string }) {
     this.parentAppWindow = parentAppWindow;


### PR DESCRIPTION
## Summary
Reduced the time flush interval for tab active time tracking from 900 seconds (15 minutes) to 60 seconds (1 minute).

## Changes
- Updated `TIME_FLUSH_INTERVAL_MS` constant in `Tab` class from `900_000` to `60_000` milliseconds
  - This increases the frequency of flushing accumulated active time data from every 15 minutes to every 1 minute
  - Allows for more frequent persistence of tab activity metrics

## Details
This change affects how often the tab's active time accumulator is flushed/persisted. The shorter interval ensures that tab activity data is saved more frequently, reducing the potential loss of activity tracking data in case of unexpected termination.

https://claude.ai/code/session_01A3Kjp8hhEV8Cmpm3ggc3eT