### PR TITLE
Add UTF-8 charset meta tag to all HTML pages

### DIFF
--- a/src/renderer/pages/about/index.html
+++ b/src/renderer/pages/about/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>About Nav0</title>
 </head>

--- a/src/renderer/pages/bookmarks/index.html
+++ b/src/renderer/pages/bookmarks/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>Bookmarks</title>
 </head>

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>Settings</title>
 </head>

--- a/src/renderer/pages/downloads/index.html
+++ b/src/renderer/pages/downloads/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>Downloads</title>
 </head>

--- a/src/renderer/pages/history/index.html
+++ b/src/renderer/pages/history/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>Browsing History</title>
 </head>

--- a/src/renderer/pages/new-tab/index.html
+++ b/src/renderer/pages/new-tab/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:;">
   <title>New Tab</title>
 </head>


### PR DESCRIPTION
## Summary
Added explicit UTF-8 character encoding declaration to all HTML pages in the renderer to ensure proper character encoding across the application.

## Changes
- Added `<meta charset="UTF-8">` to the `<head>` section of all HTML pages:
  - `src/renderer/pages/about/index.html`
  - `src/renderer/pages/bookmarks/index.html`
  - `src/renderer/pages/browser-settings/index.html`
  - `src/renderer/pages/downloads/index.html`
  - `src/renderer/pages/history/index.html`
  - `src/renderer/pages/new-tab/index.html`

## Details
The charset meta tag is placed as the first meta tag in the head section, following HTML best practices. This ensures that the browser correctly interprets all text content as UTF-8 encoded, preventing potential character encoding issues and improving compatibility across different environments.

https://claude.ai/code/session_01Dusjb2Bzr9SATaH4Hm1P53