### PR TITLE
Expand file type support and improve categorization

### DIFF
--- a/src/main/browser/download-manager.ts
+++ b/src/main/browser/download-manager.ts
@@ -292,7 +292,7 @@ export abstract class DownloadManager {
     return records;
   }
 
-  public static async addRecord(appWindowId: string, url: string, fileName: string, fileExtension: string, fileType: 'document' | 'image' | 'archive' | 'audio' | 'file' | 'executable' | 'other', fileSize: number, fileLocation: string): Promise<DownloadRecord>{
+  public static async addRecord(appWindowId: string, url: string, fileName: string, fileExtension: string, fileType: 'document' | 'image' | 'archive' | 'audio' | 'video' | 'file' | 'executable' | 'other', fileSize: number, fileLocation: string): Promise<DownloadRecord>{
     const db = DatabaseManager.getDatabase(AppWindowManager.getWindowById(appWindowId).isPrivate);
     const id = uuid();
     const createdDate = new Date().toISOString();

--- a/src/main/browser/utils.ts
+++ b/src/main/browser/utils.ts
@@ -1,20 +1,21 @@
-export abstract class Utils { 
-  public static getFileType(fileExtension: string) : "document"|"image"|"archive"|"audio"|"file"|"executable"|"other" {
+export abstract class Utils {
+  public static getFileType(fileExtension: string) : "document"|"image"|"archive"|"audio"|"video"|"file"|"executable"|"other" {
   const typeMap = {
-    document: ['pdf', 'doc', 'docx', 'txt', 'rtf', 'odt', 'xls', 'xlsx', 'csv', 'ppt', 'pptx', 'odp', 'ods', 'md', 'pages', 'numbers'],
-    image: ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp', 'tiff', 'ico', 'psd', 'ai'],
-    archive: ['zip', 'rar', '7z', 'tar', 'gz', 'bz2', 'xz', 'iso', 'dmg'],
-    audio: ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a', 'wma', 'aiff', 'opus'],
-    file: ['json', 'xml', 'yaml', 'toml', 'ini', 'cfg', 'conf', 'log', 'sql', 'dat'],
-    executable: ['exe', 'msi', 'app', 'sh', 'bat', 'cmd', 'com', 'gadget', 'jar', 'py', 'js']
+    document: ['pdf', 'doc', 'docx', 'txt', 'rtf', 'odt', 'xls', 'xlsx', 'csv', 'ppt', 'pptx', 'odp', 'ods', 'md', 'pages', 'numbers', 'tex', 'epub', 'mobi', 'ott', 'pptm', 'xlsm'],
+    image: ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp', 'tiff', 'tif', 'ico', 'psd', 'ai', 'heic', 'heif', 'avif', 'jxl', 'eps', 'raw', 'cr2', 'nef', 'dng', 'arw', 'exr', 'hdr', 'jfif', 'jpe', 'jp2', 'pcx', 'tga'],
+    archive: ['zip', 'rar', '7z', 'tar', 'gz', 'bz2', 'xz', 'iso', 'dmg', 'zst', 'cab', 'tgz', 'lz', 'lzma'],
+    audio: ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a', 'wma', 'aiff', 'opus', 'mid', 'midi', 'ape', 'amr', 'ac3', 'dts', 'mp2', 'au', 'caf', 'alac'],
+    video: ['mp4', 'mov', 'avi', 'mkv', 'wmv', 'flv', 'webm', 'm4v', 'mpg', 'mpeg', '3gp', '3g2', 'ogv', 'mxf', 'ts', 'vob'],
+    file: ['json', 'xml', 'yaml', 'toml', 'ini', 'cfg', 'conf', 'log', 'sql', 'dat', 'html', 'htm', 'css'],
+    executable: ['exe', 'msi', 'app', 'sh', 'bat', 'cmd', 'com', 'gadget', 'jar', 'py', 'js', 'deb', 'rpm', 'pkg', 'apk', 'appimage', 'snap', 'flatpak', 'ipa', 'run', 'bin']
   };
-  
+
   for (const [type, extensions] of Object.entries(typeMap) as [keyof typeof typeMap, string[]][]) {
     if (extensions.includes(fileExtension)) {
       return type;
     }
   }
-  
+
   return "other";
   }
 }

--- a/src/renderer/common/file-type-utils.ts
+++ b/src/renderer/common/file-type-utils.ts
@@ -2,18 +2,18 @@
 
 /** Color palette for file display types. */
 export const TYPE_COLORS: Record<string, string> = {
-  document: '#6366f1',
-  spreadsheet: '#6366f1',
-  presentation: '#6366f1',
-  ebook: '#f97316',
-  image: '#06b6d4',
-  video: '#06b6d4',
-  installer: '#f59e0b',
-  archive: '#8b5cf6',
-  audio: '#ec4899',
-  code: '#10b981',
-  font: '#64748b',
-  other: '#a1a1aa',
+  document: '#6366f1',        // Indigo
+  spreadsheet: '#22c55e',     // Green
+  presentation: '#3b82f6',    // Blue
+  ebook: '#f97316',           // Orange
+  image: '#06b6d4',           // Cyan
+  video: '#ef4444',           // Red
+  installer: '#f59e0b',       // Amber
+  archive: '#8b5cf6',         // Purple
+  audio: '#ec4899',           // Pink
+  code: '#10b981',            // Emerald
+  font: '#64748b',            // Slate
+  other: '#a1a1aa',           // Gray
 };
 
 /** Maps file extensions to a human-friendly display type. */

--- a/src/renderer/common/file-type-utils.ts
+++ b/src/renderer/common/file-type-utils.ts
@@ -5,12 +5,14 @@ export const TYPE_COLORS: Record<string, string> = {
   document: '#6366f1',
   spreadsheet: '#6366f1',
   presentation: '#6366f1',
+  ebook: '#f97316',
   image: '#06b6d4',
   video: '#06b6d4',
   installer: '#f59e0b',
   archive: '#8b5cf6',
   audio: '#ec4899',
   code: '#10b981',
+  font: '#64748b',
   other: '#a1a1aa',
 };
 
@@ -18,11 +20,16 @@ export const TYPE_COLORS: Record<string, string> = {
 export const EXTENSION_TYPE_MAP: Record<string, string> = {
   // Documents
   pdf: 'document', doc: 'document', docx: 'document', txt: 'document',
-  rtf: 'document', odt: 'document', md: 'document', pages: 'document',
-  tex: 'document', latex: 'document', epub: 'document', mobi: 'document',
+  rtf: 'document', odt: 'document', ott: 'document', md: 'document', pages: 'document',
+  tex: 'document', latex: 'document',
   djvu: 'document', xps: 'document', oxps: 'document', wp: 'document',
   wpd: 'document', wps: 'document', hwp: 'document', hwpx: 'document',
   log: 'document', nfo: 'document', readme: 'document',
+
+  // Ebooks
+  epub: 'ebook', mobi: 'ebook', azw: 'ebook', azw3: 'ebook',
+  fb2: 'ebook', lit: 'ebook', lrf: 'ebook', pdb: 'ebook',
+  cbz: 'ebook', cbr: 'ebook',
 
   // Spreadsheets
   csv: 'spreadsheet', xlsx: 'spreadsheet', xls: 'spreadsheet',
@@ -34,12 +41,15 @@ export const EXTENSION_TYPE_MAP: Record<string, string> = {
   pptm: 'presentation', key: 'presentation', ppsx: 'presentation',
 
   // Images
-  jpg: 'image', jpeg: 'image', png: 'image', gif: 'image', svg: 'image',
+  jpg: 'image', jpeg: 'image', jpe: 'image', jfif: 'image', jp2: 'image',
+  png: 'image', gif: 'image', svg: 'image',
   bmp: 'image', webp: 'image', tiff: 'image', tif: 'image', ico: 'image',
   psd: 'image', ai: 'image', eps: 'image', raw: 'image', cr2: 'image',
   nef: 'image', orf: 'image', sr2: 'image', arw: 'image', dng: 'image',
   heic: 'image', heif: 'image', avif: 'image', jxl: 'image',
   xcf: 'image', sketch: 'image', fig: 'image', indd: 'image',
+  pcx: 'image', tga: 'image', pgm: 'image', ppm: 'image', pbm: 'image', pam: 'image',
+  exr: 'image', hdr: 'image', dds: 'image', cur: 'image', sgi: 'image', dpx: 'image',
 
   // Audio
   mp3: 'audio', wav: 'audio', ogg: 'audio', flac: 'audio', aac: 'audio',
@@ -47,6 +57,8 @@ export const EXTENSION_TYPE_MAP: Record<string, string> = {
   midi: 'audio', ape: 'audio', alac: 'audio', dsf: 'audio', dff: 'audio',
   wv: 'audio', mka: 'audio', ac3: 'audio', dts: 'audio', pcm: 'audio',
   amr: 'audio', ra: 'audio', caf: 'audio',
+  au: 'audio', mp2: 'audio', voc: 'audio', w64: 'audio', snd: 'audio',
+  gsm: 'audio', iff: 'audio', '8svx': 'audio',
 
   // Video
   mp4: 'video', mov: 'video', avi: 'video', mkv: 'video',
@@ -54,7 +66,7 @@ export const EXTENSION_TYPE_MAP: Record<string, string> = {
   mpg: 'video', mpeg: 'video', '3gp': 'video', '3g2': 'video',
   ts: 'video', mts: 'video', m2ts: 'video', vob: 'video',
   ogv: 'video', rm: 'video', rmvb: 'video', asf: 'video',
-  divx: 'video', f4v: 'video', swf: 'video',
+  divx: 'video', f4v: 'video', swf: 'video', mxf: 'video',
 
   // Archives
   zip: 'archive', rar: 'archive', '7z': 'archive', tar: 'archive',
@@ -100,7 +112,9 @@ export const EXTENSION_TYPE_MAP: Record<string, string> = {
   gradle: 'code', sbt: 'code', pom: 'code',
 
   // Fonts
-  ttf: 'other', otf: 'other', woff: 'other', woff2: 'other', eot: 'other',
+  ttf: 'font', otf: 'font', woff: 'font', woff2: 'font', eot: 'font',
+  pfb: 'font', pfm: 'font', sfd: 'font', dfont: 'font', bdf: 'font',
+  fon: 'font', ttc: 'font',
 
   // 3D / CAD
   stl: 'other', obj: 'other', fbx: 'other', gltf: 'other', glb: 'other',
@@ -142,11 +156,16 @@ export const hexToRgba = (hex: string, alpha: number): string => {
 const FILE_ICON_MAP: Record<string, string> = {
   // Documents - Text
   pdf: 'file-text', doc: 'file-text', docx: 'file-text', txt: 'file-text',
-  rtf: 'file-text', odt: 'file-text', md: 'file-text', pages: 'file-text',
-  tex: 'file-text', latex: 'file-text', epub: 'file-text', mobi: 'file-text',
+  rtf: 'file-text', odt: 'file-text', ott: 'file-text', md: 'file-text', pages: 'file-text',
+  tex: 'file-text', latex: 'file-text',
   djvu: 'file-text', xps: 'file-text', oxps: 'file-text', wp: 'file-text',
   wpd: 'file-text', wps: 'file-text', hwp: 'file-text', hwpx: 'file-text',
   nfo: 'file-text', readme: 'file-text', log: 'file-text',
+
+  // Ebooks
+  epub: 'book-open', mobi: 'book-open', azw: 'book-open', azw3: 'book-open',
+  fb2: 'book-open', lit: 'book-open', lrf: 'book-open', pdb: 'book-open',
+  cbz: 'book-open', cbr: 'book-open',
 
   // Spreadsheets
   csv: 'file-spreadsheet', xlsx: 'file-spreadsheet', xls: 'file-spreadsheet',
@@ -158,12 +177,15 @@ const FILE_ICON_MAP: Record<string, string> = {
   pptm: 'file-presentation', key: 'file-presentation', ppsx: 'file-presentation',
 
   // Images
-  jpg: 'image', jpeg: 'image', png: 'image', gif: 'image', svg: 'image',
+  jpg: 'image', jpeg: 'image', jpe: 'image', jfif: 'image', jp2: 'image',
+  png: 'image', gif: 'image', svg: 'image',
   bmp: 'image', webp: 'image', tiff: 'image', tif: 'image', ico: 'image',
   psd: 'image', ai: 'image', eps: 'image', raw: 'image', cr2: 'image',
   nef: 'image', orf: 'image', sr2: 'image', arw: 'image', dng: 'image',
   heic: 'image', heif: 'image', avif: 'image', jxl: 'image',
   xcf: 'image', sketch: 'image', fig: 'image', indd: 'image',
+  pcx: 'image', tga: 'image', pgm: 'image', ppm: 'image', pbm: 'image', pam: 'image',
+  exr: 'image', hdr: 'image', dds: 'image', cur: 'image', sgi: 'image', dpx: 'image',
 
   // Audio
   mp3: 'music', wav: 'music', ogg: 'music', flac: 'music', aac: 'music',
@@ -171,6 +193,8 @@ const FILE_ICON_MAP: Record<string, string> = {
   midi: 'music', ape: 'music', alac: 'music', dsf: 'music', dff: 'music',
   wv: 'music', mka: 'music', ac3: 'music', dts: 'music', pcm: 'music',
   amr: 'music', ra: 'music', caf: 'music',
+  au: 'music', mp2: 'music', voc: 'music', w64: 'music', snd: 'music',
+  gsm: 'music', iff: 'music', '8svx': 'music',
 
   // Video
   mp4: 'video', mov: 'video', avi: 'video', mkv: 'video',
@@ -178,7 +202,7 @@ const FILE_ICON_MAP: Record<string, string> = {
   mpg: 'video', mpeg: 'video', '3gp': 'video', '3g2': 'video',
   ts: 'video', mts: 'video', m2ts: 'video', vob: 'video',
   ogv: 'video', rm: 'video', rmvb: 'video', asf: 'video',
-  divx: 'video', f4v: 'video', swf: 'video',
+  divx: 'video', f4v: 'video', swf: 'video', mxf: 'video',
 
   // Archives
   zip: 'file-archive', rar: 'file-archive', '7z': 'file-archive',
@@ -231,6 +255,8 @@ const FILE_ICON_MAP: Record<string, string> = {
 
   // Fonts
   ttf: 'type', otf: 'type', woff: 'type', woff2: 'type', eot: 'type',
+  pfb: 'type', pfm: 'type', sfd: 'type', dfont: 'type', bdf: 'type',
+  fon: 'type', ttc: 'type',
 
   // 3D / CAD
   stl: 'box', obj: 'box', fbx: 'box', gltf: 'box', glb: 'box',

--- a/src/types/download-record.ts
+++ b/src/types/download-record.ts
@@ -4,7 +4,7 @@ export type DownloadRecord = {
   fileName: string,
   url: string,
   fileExtension: string,
-  fileType: 'document' | 'image' | 'archive' | 'audio' | 'file' | 'executable' | 'other',
+  fileType: 'document' | 'image' | 'archive' | 'audio' | 'video' | 'file' | 'executable' | 'other',
   fileSize: number,
   fileLocation: string,
   status: 'completed' | 'in_progress' | 'paused' | 'cancelled',


### PR DESCRIPTION
## Summary
This PR significantly expands file type support across the application by adding new file categories, extending existing ones with additional extensions, and improving color differentiation for better visual distinction.

## Key Changes

### New File Categories
- **Ebook category**: Introduced new `ebook` type for e-book formats (epub, mobi, azw, azw3, fb2, lit, lrf, pdb, cbz, cbr) with dedicated orange color (#f97316) and book-open icon
- **Font category**: Separated font files from "other" category with dedicated slate color (#64748b) and type icon, supporting ttf, otf, woff, woff2, eot, pfb, pfm, sfd, dfont, bdf, fon, ttc

### Enhanced File Type Support
- **Images**: Added 16 new formats including jpe, jfif, jp2, pcx, tga, pgm, ppm, pbm, pam, exr, hdr, dds, cur, sgi, dpx
- **Audio**: Added 8 new formats including au, mp2, voc, w64, snd, gsm, iff, 8svx
- **Video**: Added mxf format and added video as a distinct type in the file type system
- **Archives**: Added zst, cab, tgz, lz, lzma formats
- **Documents**: Added ott (OpenDocument template) and moved ebook formats to new category
- **Executables**: Expanded with deb, rpm, pkg, apk, appimage, snap, flatpak, ipa, run, bin

### Color Improvements
- Updated color palette with better visual distinction:
  - Spreadsheet: Changed from indigo to green (#22c55e)
  - Presentation: Changed from indigo to blue (#3b82f6)
  - Video: Changed from cyan to red (#ef4444)
  - Added comments documenting color names for maintainability

### Type System Updates
- Added `video` as a distinct file type in `Utils.getFileType()`, `DownloadManager.addRecord()`, and `DownloadRecord` type definition
- Updated file icon mappings to match new categorization

### Code Quality
- Added inline comments to color palette for better maintainability
- Improved formatting and consistency across type definitions

https://claude.ai/code/session_014sX5NUgdoTpxEjcpbpLHz4