### PR TITLE
Add session restoration feature to restore previous browser state

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -147,6 +147,8 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly RESTORE_CLOSED_TAB_BY_INDEX = "browser:restore-closed-tab-by-index";
   public static readonly FETCH_CLOSED_WINDOWS = "browser:fetch-closed-windows";
   public static readonly RESTORE_CLOSED_WINDOW = "browser:restore-closed-window";
+  public static readonly FETCH_SESSION_STATE = "browser:fetch-session-state";
+  public static readonly RESTORE_PREVIOUS_SESSION = "browser:restore-previous-session";
   public static readonly SHOW_ABOUT_PANEL = "browser:show-about-panel";
   public static readonly GET_ABOUT_INFO = "browser:get-about-info";
   public static readonly TOGGLE_READER_MODE = "browser:toggle-reader-mode";
@@ -224,6 +226,7 @@ export abstract class DataStoreConstants {
   public static readonly DEFAULT_KEY = 'default';
   public static readonly BROWSER_SETTINGS = "browser-settings";
   public static readonly CLOSED_WINDOWS = "closed-windows";
+  public static readonly SESSION_STATE = "session-state";
 }
 
 export interface ClosedTabRecord {
@@ -237,6 +240,23 @@ export interface ClosedWindowRecord {
   tabCount: number;
   tabs: { url: string; title: string }[];
   closedAt: number;
+}
+
+export interface SessionTabRecord {
+  url: string;
+  title: string;
+  faviconUrl: string | null;
+}
+
+export interface SessionWindowRecord {
+  tabs: SessionTabRecord[];
+  activeTabIndex: number;
+}
+
+export interface SessionState {
+  windows: SessionWindowRecord[];
+  savedAt: number;
+  restored: boolean;
 }
 
 export abstract class RendererToMainEventsForDataStoreIPC {

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -5,6 +5,7 @@ import { app, dialog, ipcMain, Menu } from "electron";
 import { Tab } from "./tab";
 import { DatabaseManager } from "../database/database-manager";
 import { DataStoreManager } from "../database/data-store-manager";
+import { SessionManager } from "./session-manager";
 import { SearchEngine } from "../web/search-engine";
 import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from "../../types/settings-types";
 import { PermissionManager, PermissionRequest } from "./permission-manager";
@@ -86,10 +87,14 @@ export abstract class AppWindowManager {
         }
       }
     );
-    AppWindowManager.createWindow();
+    const sessionRestored = await SessionManager.restoreSession();
+    if (!sessionRestored) {
+      AppWindowManager.createWindow();
+    }
     AppWindowManager.initIPCHandlers();
     AppMenuManager.init();
     AppWindowManager.startHibernationChecker();
+    SessionManager.startPeriodicSave();
   }
   static createWindow(isPrivate = false): AppWindow {
     const window = new AppWindow(isPrivate, DatabaseManager.getDatabase(isPrivate));
@@ -751,6 +756,21 @@ export abstract class AppWindowManager {
         newWindow.createSuspendedTab(restoredUrls[i].url, restoredUrls[i].title || 'Restored Tab');
       }
       return { ok: true };
+    });
+
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.FETCH_SESSION_STATE, async () => {
+      const session = SessionManager.getSavedSession();
+      if (!session) return null;
+      return {
+        windowCount: session.windows.length,
+        totalTabCount: session.windows.reduce((sum, w) => sum + w.tabs.length, 0),
+        savedAt: session.savedAt,
+      };
+    });
+
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.RESTORE_PREVIOUS_SESSION, async () => {
+      const restored = await SessionManager.restoreSession();
+      return { ok: restored };
     });
 
     ipcMain.on(RendererToMainEventsForBrowserIPC.PRINT_PAGE, async (event, appWindowId: string) => {

--- a/src/main/browser/session-manager.ts
+++ b/src/main/browser/session-manager.ts
@@ -1,0 +1,126 @@
+import { DataStoreConstants, InAppUrls, SessionState, SessionWindowRecord } from "../../constants/app-constants";
+import { DataStoreManager } from "../database/data-store-manager";
+import { AppWindowManager } from "./app-window-manager";
+
+export abstract class SessionManager {
+  private static periodicSaveTimer: ReturnType<typeof setInterval> | null = null;
+  private static readonly PERIODIC_SAVE_INTERVAL_MS = 60 * 1000; // 60 seconds
+
+  public static startPeriodicSave(): void {
+    if (SessionManager.periodicSaveTimer) return;
+    SessionManager.periodicSaveTimer = setInterval(() => {
+      SessionManager.saveCurrentSession();
+    }, SessionManager.PERIODIC_SAVE_INTERVAL_MS);
+  }
+
+  public static stopPeriodicSave(): void {
+    if (SessionManager.periodicSaveTimer) {
+      clearInterval(SessionManager.periodicSaveTimer);
+      SessionManager.periodicSaveTimer = null;
+    }
+  }
+
+  public static saveCurrentSession(): void {
+    const windows = AppWindowManager.getWindows();
+    const sessionWindows: SessionWindowRecord[] = [];
+
+    for (const win of windows) {
+      if (win.isPrivate) continue;
+
+      const tabs = win.getTabs();
+      const activeTabId = win.getActiveTabId();
+
+      const filteredTabs: { url: string; title: string; faviconUrl: string | null; isActive: boolean }[] = [];
+      for (const tab of tabs) {
+        const url = tab.getUrl();
+        if (!url || url === '' || url.startsWith(InAppUrls.PREFIX)) continue;
+        filteredTabs.push({
+          url,
+          title: tab.getTitle(),
+          faviconUrl: tab.getFaviconUrl(),
+          isActive: tab.getId() === activeTabId,
+        });
+      }
+
+      if (filteredTabs.length === 0) continue;
+
+      let activeTabIndex = filteredTabs.findIndex(t => t.isActive);
+      if (activeTabIndex === -1) activeTabIndex = 0;
+
+      sessionWindows.push({
+        tabs: filteredTabs.map(t => ({ url: t.url, title: t.title, faviconUrl: t.faviconUrl })),
+        activeTabIndex,
+      });
+    }
+
+    if (sessionWindows.length === 0) {
+      SessionManager.clearSession();
+      return;
+    }
+
+    const sessionState: SessionState = {
+      windows: sessionWindows,
+      savedAt: Date.now(),
+      restored: false,
+    };
+
+    DataStoreManager.set(DataStoreConstants.SESSION_STATE, sessionState);
+  }
+
+  public static getSavedSession(): SessionState | null {
+    const data = DataStoreManager.get(DataStoreConstants.SESSION_STATE);
+    if (!data || data.restored || !data.windows || data.windows.length === 0) {
+      return null;
+    }
+    return data as SessionState;
+  }
+
+  public static markSessionRestored(): void {
+    const data = DataStoreManager.get(DataStoreConstants.SESSION_STATE);
+    if (data) {
+      data.restored = true;
+      DataStoreManager.set(DataStoreConstants.SESSION_STATE, data);
+    }
+  }
+
+  public static clearSession(): void {
+    DataStoreManager.set(DataStoreConstants.SESSION_STATE, null);
+  }
+
+  public static async restoreSession(): Promise<boolean> {
+    const session = SessionManager.getSavedSession();
+    if (!session) return false;
+
+    for (const windowRecord of session.windows) {
+      if (windowRecord.tabs.length === 0) continue;
+
+      const newWindow = AppWindowManager.createWindow(false);
+      await newWindow.whenReady();
+
+      // Navigate the default tab to the first restored URL
+      const defaultTabs = newWindow.getTabs();
+      if (defaultTabs.length > 0) {
+        defaultTabs[0].navigate(windowRecord.tabs[0].url);
+      }
+
+      // Create remaining tabs — active tab loads, others are suspended
+      for (let i = 1; i < windowRecord.tabs.length; i++) {
+        const tabRecord = windowRecord.tabs[i];
+        if (i === windowRecord.activeTabIndex) {
+          await newWindow.createTab(tabRecord.url, false);
+        } else {
+          newWindow.createSuspendedTab(tabRecord.url, tabRecord.title || 'Restored Tab');
+        }
+      }
+
+      // Activate the correct tab
+      const allTabs = newWindow.getTabs();
+      if (windowRecord.activeTabIndex < allTabs.length) {
+        newWindow.activateTab(allTabs[windowRecord.activeTabIndex].getId());
+      }
+    }
+
+    SessionManager.markSessionRestored();
+    return true;
+  }
+}

--- a/src/main/database/data-store-manager.ts
+++ b/src/main/database/data-store-manager.ts
@@ -24,6 +24,7 @@ export abstract class DataStoreManager {
   private static initStores(): void {
     DataStoreManager.stores.set(DataStoreConstants.BROWSER_SETTINGS, new Store({ name: DataStoreConstants.BROWSER_SETTINGS, defaults: {'default' : DataStoreManager.getDefaultValue(DataStoreConstants.BROWSER_SETTINGS)}  as Record<string, any>}));
     DataStoreManager.stores.set(DataStoreConstants.CLOSED_WINDOWS, new Store({ name: DataStoreConstants.CLOSED_WINDOWS, defaults: {'default' : DataStoreManager.getDefaultValue(DataStoreConstants.CLOSED_WINDOWS)}  as Record<string, any>}));
+    DataStoreManager.stores.set(DataStoreConstants.SESSION_STATE, new Store({ name: DataStoreConstants.SESSION_STATE, defaults: {'default' : DataStoreManager.getDefaultValue(DataStoreConstants.SESSION_STATE)}  as Record<string, any>}));
   }
 
 
@@ -128,6 +129,9 @@ export abstract class DataStoreManager {
         break;
       case DataStoreConstants.CLOSED_WINDOWS:
         returnValue = [];
+        break;
+      case DataStoreConstants.SESSION_STATE:
+        returnValue = null;
         break;
       default:
         break;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import { AppWindowManager } from './browser/app-window-manager';
 import { DataStoreManager } from './database/data-store-manager';
 import { DownloadManager } from './browser/download-manager';
+import { SessionManager } from './browser/session-manager';
 import { SettingsEnforcer } from './settings/settings-enforcer';
 import { startTestControlServer } from './test-control-server';
 
@@ -30,6 +31,12 @@ app.whenReady().then(async() => {
   if (testPort > 0) {
     startTestControlServer(testPort);
   }
+});
+
+// Save session state before quit (must run before downloads/settings cleanup)
+app.on('before-quit', () => {
+  SessionManager.stopPeriodicSave();
+  SessionManager.saveCurrentSession();
 });
 
 // Pause all in-progress downloads before quitting so they can be resumed later

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -210,6 +210,12 @@ export function init(){
     restoreClosedWindow: async (index: number) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.RESTORE_CLOSED_WINDOW, index);
     },
+    fetchSessionState: async () => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.FETCH_SESSION_STATE);
+    },
+    restorePreviousSession: async () => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.RESTORE_PREVIOUS_SESSION);
+    },
     toggleReaderMode: async (appWindowId: string, tabId: string) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.TOGGLE_READER_MODE, appWindowId, tabId);
     },

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -79,6 +79,8 @@ declare global {
       restoreClosedTabByIndex: (appWindowId: string, index: number) => Promise<{id: string, title: string, url: string} | null>;
       fetchClosedWindows: () => Promise<Array<{tabCount: number, tabs: Array<{url: string, title: string}>, closedAt: number}>>;
       restoreClosedWindow: (index: number) => Promise<{ok: boolean} | null>;
+      fetchSessionState: () => Promise<{ windowCount: number; totalTabCount: number; savedAt: number } | null>;
+      restorePreviousSession: () => Promise<{ ok: boolean } | null>;
       toggleReaderMode: (appWindowId: string, tabId: string) => Promise<any>;
       downloadCurrentPdf: (appWindowId: string, tabId: string) => Promise<any>;
       // Event listeners

--- a/src/renderer/overlay/panels/options-menu/options-menu.ts
+++ b/src/renderer/overlay/panels/options-menu/options-menu.ts
@@ -84,6 +84,13 @@ const OPTIONS_MENU_HTML = `
           <div id="om-recently-closed-windows-list">
             <div class="submenu-empty-state">No recently closed windows</div>
           </div>
+
+          <!-- Section 4: Restore Previous Session -->
+          <div class="divider" id="om-restore-session-divider" style="display:none"></div>
+          <div class="dropdown-item" id="om-restore-session-option" style="display:none">
+            <i data-lucide="rotate-ccw" width="16" height="16"></i>
+            <span class="dropdown-item-text">Restore Previous Session</span>
+          </div>
         </div>
       </div>
 
@@ -249,6 +256,30 @@ async function populateHistorySubmenu(): Promise<void> {
     }
   } else if (windowsList && isPrivate) {
     windowsList.innerHTML = '<div class="submenu-empty-state">Not available in private mode</div>';
+  }
+
+  // Populate "Restore Previous Session" option
+  const restoreSessionDivider = containerEl.querySelector('#om-restore-session-divider') as HTMLElement;
+  const restoreSessionItem = containerEl.querySelector('#om-restore-session-option') as HTMLElement;
+  if (restoreSessionItem && restoreSessionDivider && !isPrivate) {
+    const sessionState = await window.BrowserAPI.fetchSessionState();
+    if (sessionState) {
+      restoreSessionDivider.style.display = '';
+      restoreSessionItem.style.display = '';
+      const newItem = restoreSessionItem.cloneNode(true) as HTMLElement;
+      restoreSessionItem.parentNode?.replaceChild(newItem, restoreSessionItem);
+      newItem.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        await window.BrowserAPI.restorePreviousSession();
+        await window.BrowserAPI.hideOptionsMenu(appWindowId);
+      });
+    } else {
+      restoreSessionDivider.style.display = 'none';
+      restoreSessionItem.style.display = 'none';
+    }
+  } else if (restoreSessionItem && restoreSessionDivider) {
+    restoreSessionDivider.style.display = 'none';
+    restoreSessionItem.style.display = 'none';
   }
 }
 


### PR DESCRIPTION
## Summary
This PR implements a session management system that automatically saves the browser's window and tab state periodically, and allows users to restore their previous session on startup or via the options menu.

## Key Changes

- **New SessionManager class** (`src/main/browser/session-manager.ts`): Core session management with the following capabilities:
  - Periodic automatic saving of open windows and tabs every 60 seconds
  - Session restoration on app startup
  - Filtering of private windows and in-app URLs from saved state
  - Tracking of active tabs and window state

- **Session state persistence**: Added `SESSION_STATE` data store to persist session data across app restarts

- **UI integration**: Added "Restore Previous Session" option to the options menu that:
  - Only appears when a saved session exists
  - Is hidden in private mode
  - Triggers session restoration when clicked

- **IPC handlers**: Added two new IPC events:
  - `FETCH_SESSION_STATE`: Retrieves metadata about saved session (window count, tab count, save time)
  - `RESTORE_PREVIOUS_SESSION`: Triggers session restoration

- **App lifecycle integration**:
  - Session saving starts on app initialization
  - Session is saved before app quit to capture final state
  - Session restoration attempted on startup before creating default window

- **Preload API**: Exposed `fetchSessionState()` and `restorePreviousSession()` methods to renderer process

## Implementation Details

- Sessions exclude private windows and in-app URLs (e.g., settings, about pages)
- Active tab index is preserved and restored for each window
- Inactive tabs are created in suspended state to improve performance
- Session is marked as "restored" after restoration to prevent duplicate restores
- Empty sessions are automatically cleared to avoid cluttering the data store

https://claude.ai/code/session_01Q6QZdcHbfXbogCQ4D7jvpU