### PR TITLE
Add General settings section with custom downloads location

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -119,6 +119,7 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly CANCEL_DOWNLOAD = "browser:cancel-download";
   public static readonly OPEN_DOWNLOADED_FILE = "browser:open-downloaded-file";
   public static readonly SHOW_ITEM_IN_FOLDER = "browser:show-item-in-folder";
+  public static readonly SELECT_DOWNLOAD_FOLDER = "browser:select-download-folder";
   public static readonly REMOVE_BROWSING_HISTORY = "browser:remove-browsing-history";
   public static readonly REMOVE_ALL_BROWSING_HISTORY = "browser:remove-all-browsing-history";
   public static readonly FETCH_BROWSING_HISTORY = "browser:fetch-browsing-history";

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -962,5 +962,19 @@ export abstract class AppWindowManager {
       return fileUrl;
     });
 
+    ipcMain.handle(RendererToMainEventsForBrowserIPC.SELECT_DOWNLOAD_FOLDER, async () => {
+      const window = AppWindowManager.getActiveWindow();
+      if (!window) return null;
+
+      const result = await dialog.showOpenDialog(window.getBrowserWindowInstance(), {
+        properties: ['openDirectory'],
+        title: 'Select Downloads Folder',
+        defaultPath: app.getPath('downloads'),
+      });
+
+      if (result.canceled || result.filePaths.length === 0) return null;
+      return result.filePaths[0];
+    });
+
   }
 }

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -516,7 +516,13 @@ export class Tab {
   }
 
   async handleDownload(item: Electron.DownloadItem): Promise<void> {
-    const downloadPath = app.getPath('downloads') + '/' + item.getFilename();
+    const storedSettings = DataStoreManager.get(DataStoreConstants.BROWSER_SETTINGS) as BrowserSettings;
+    const s = { ...DEFAULT_BROWSER_SETTINGS, ...storedSettings };
+    let downloadDir = s.downloadPath || app.getPath('downloads');
+    if (s.downloadPath && !fs.existsSync(s.downloadPath)) {
+      downloadDir = app.getPath('downloads');
+    }
+    const downloadPath = path.join(downloadDir, item.getFilename());
     const downloadId = item.getStartTime().toString() + '_' + item.getFilename();
 
     // Prevent duplicate handling when multiple tabs share the same session

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -96,6 +96,9 @@ export function init(){
     showItemInFolder: async (filePath: string) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.SHOW_ITEM_IN_FOLDER, filePath);
     },
+    selectDownloadFolder: async () => {
+      return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.SELECT_DOWNLOAD_FOLDER);
+    },
     removeBrowsingHistory: async (appWindowId: string, historyId: string) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.REMOVE_BROWSING_HISTORY, appWindowId, historyId);
     },

--- a/src/renderer/pages/browser-settings/index.html
+++ b/src/renderer/pages/browser-settings/index.html
@@ -14,7 +14,8 @@
         <i data-lucide="search" class="sidebar-search-icon"></i>
       </div>
       <ul class="sidebar-nav">
-        <li><a href="#search" class="sidebar-link active" data-section="search"><i data-lucide="search" width="16" height="16"></i> Search</a></li>
+        <li><a href="#general" class="sidebar-link active" data-section="general"><i data-lucide="settings" width="16" height="16"></i> General</a></li>
+        <li><a href="#search" class="sidebar-link" data-section="search"><i data-lucide="search" width="16" height="16"></i> Search</a></li>
         <li><a href="#privacy" class="sidebar-link" data-section="privacy"><i data-lucide="shield" width="16" height="16"></i> Privacy &amp; Security</a></li>
         <li><a href="#network" class="sidebar-link" data-section="network"><i data-lucide="globe" width="16" height="16"></i> Network</a></li>
         <li><a href="#shortcuts" class="sidebar-link" data-section="shortcuts"><i data-lucide="keyboard" width="16" height="16"></i> Keyboard Shortcuts</a></li>
@@ -26,8 +27,28 @@
     <div class="settings-content-wrapper">
     <main class="settings-content" id="settings-content">
 
+      <!-- ====== GENERAL SECTION ====== -->
+      <section id="section-general" class="settings-section active" data-keywords="general downloads download location folder path save directory">
+        <h2 class="section-title">General</h2>
+
+        <!-- Downloads Location -->
+        <div class="setting-group">
+          <label class="setting-label">Downloads Location</label>
+          <p class="setting-description">Choose where downloaded files are saved.</p>
+          <div class="setting-action-row">
+            <div style="min-width: 0; flex: 1;">
+              <span id="download-path-display" class="setting-description" style="margin: 0; word-break: break-all;"></span>
+            </div>
+            <div style="display: flex; gap: 6px;">
+              <button class="btn btn-sm btn-secondary" id="change-download-path-btn"><i data-lucide="folder" width="14" height="14"></i> Change</button>
+              <button class="btn btn-sm btn-ghost" id="reset-download-path-btn"><i data-lucide="rotate-ccw" width="14" height="14"></i> Reset</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <!-- ====== SEARCH SECTION ====== -->
-      <section id="section-search" class="settings-section active" data-keywords="search engine default query url bar duckduckgo google bing brave startpage ecosia custom suggestions">
+      <section id="section-search" class="settings-section" data-keywords="search engine default query url bar duckduckgo google bing brave startpage ecosia custom suggestions">
         <h2 class="section-title">Search</h2>
 
         <!-- Default Search Engine -->

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -15,6 +15,7 @@ const modKey = isMac ? 'Cmd' : 'Ctrl';
 document.addEventListener('DOMContentLoaded', async () => {
   await loadSettings();
   initSidebarNavigation();
+  initGeneralSettings();
   initSearchSettings();
   initCookieSettings();
   initAdBlockerSettings();
@@ -62,7 +63,7 @@ function initSidebarNavigation() {
     });
   });
   // Activate first section
-  activateSection('search');
+  activateSection('general');
 }
 
 function activateSection(sectionId: string) {
@@ -114,6 +115,38 @@ function initSettingsSearch() {
         section.classList.remove('active');
       }
     });
+  });
+}
+
+// ---- General Settings ----
+function initGeneralSettings() {
+  const pathDisplay = document.getElementById('download-path-display');
+  const changeBtn = document.getElementById('change-download-path-btn');
+  const resetBtn = document.getElementById('reset-download-path-btn');
+
+  function updatePathDisplay() {
+    if (pathDisplay) {
+      pathDisplay.textContent = settings.downloadPath || 'Default downloads folder';
+    }
+  }
+
+  updatePathDisplay();
+
+  changeBtn?.addEventListener('click', async () => {
+    const folder = await (window as any).BrowserAPI.selectDownloadFolder();
+    if (folder) {
+      settings.downloadPath = folder;
+      saveSettings();
+      updatePathDisplay();
+      showToast('Downloads location updated');
+    }
+  });
+
+  resetBtn?.addEventListener('click', () => {
+    settings.downloadPath = '';
+    saveSettings();
+    updatePathDisplay();
+    showToast('Downloads location reset to default');
   });
 }
 

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -30,6 +30,9 @@ export interface KeyboardShortcutAction {
 export interface BrowserSettings {
   settings_version: number;
 
+  // General
+  downloadPath: string;
+
   // Search
   primarySearchEngine: string;
   customSearchEngines: SearchEngineConfig[];
@@ -227,6 +230,9 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
 
 export const DEFAULT_BROWSER_SETTINGS: BrowserSettings = {
   settings_version: 1,
+
+  // General - Downloads (empty string = OS default)
+  downloadPath: '',
 
   // Search - DuckDuckGo as default (privacy-aligned)
   primarySearchEngine: 'Google',


### PR DESCRIPTION
## Summary
This PR adds a new General settings section to the browser settings page, allowing users to customize their downloads folder location. The General section is now the default landing page when opening settings.

## Key Changes
- **New General Settings Section**: Added a dedicated General settings page with Downloads Location configuration
  - Users can change the downloads folder via a file picker dialog
  - Users can reset to the OS default downloads folder
  - Current path is displayed with visual feedback via toast notifications

- **Settings UI Updates**:
  - Added "General" as the first item in the settings sidebar navigation
  - Changed default active section from "Search" to "General"
  - Added appropriate icons and styling for the new section

- **Backend Implementation**:
  - Added `downloadPath` property to `BrowserSettings` interface (defaults to empty string for OS default)
  - Implemented `SELECT_DOWNLOAD_FOLDER` IPC handler to show native folder picker dialog
  - Updated download handling logic to respect custom download path with fallback to OS default if path becomes invalid
  - Added proper path validation to ensure downloads proceed even if custom path is deleted

- **Preload API**: Exposed `selectDownloadFolder()` method to renderer process for folder selection

## Implementation Details
- The custom download path is stored in browser settings and persists across sessions
- If a custom path no longer exists, downloads automatically fall back to the OS default downloads folder
- Uses `path.join()` for cross-platform path handling instead of string concatenation
- Settings are validated on load to prevent broken configurations

https://claude.ai/code/session_016TtS35X2R9xfBT47WSKzza