### PR TITLE
Improve settings initialization resilience and DevTools policy enforcement

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -17,7 +17,21 @@ export abstract class SettingsEnforcer {
     SettingsEnforcer.applyUserAgent(settings);
     SettingsEnforcer.applyAdBlocker(settings);
     SettingsEnforcer.startAutoDeleteScheduler(settings);
+    SettingsEnforcer.applyDevToolsPolicy(settings);
     SettingsEnforcer.runStartupCleanup(settings);
+  }
+
+  // ---- DevTools Policy ----
+  // When devtools is disabled, close any open devtools across all webContents.
+  private static applyDevToolsPolicy(settings: BrowserSettings) {
+    if (settings.devToolsEnabled) return;
+    for (const wc of webContents.getAllWebContents()) {
+      try {
+        if (wc.isDevToolsOpened()) {
+          wc.closeDevTools();
+        }
+      } catch { /* ignore */ }
+    }
   }
 
   private static getSettings(): BrowserSettings {
@@ -33,6 +47,7 @@ export abstract class SettingsEnforcer {
       SettingsEnforcer.applyUserAgent(settings);
       SettingsEnforcer.applyAdBlocker(settings);
       SettingsEnforcer.startAutoDeleteScheduler(settings);
+      SettingsEnforcer.applyDevToolsPolicy(settings);
       return true;
     });
 

--- a/src/renderer/overlay/panels/options-menu/options-menu.ts
+++ b/src/renderer/overlay/panels/options-menu/options-menu.ts
@@ -380,7 +380,16 @@ export function init(container: HTMLElement): void {
 }
 
 export function show(_data?: any): void {
-  // Nothing special needed on show - the dropdown is already rendered
+  // Hide the Developer Tools option when devtools is disabled in settings.
+  window.DataStoreAPI.get('browser-settings').then((stored: unknown) => {
+    const devToolsEnabled = stored && typeof stored === 'object' && 'devToolsEnabled' in stored
+      ? !!(stored as { devToolsEnabled?: boolean }).devToolsEnabled
+      : true;
+    const devtoolsItem = containerEl?.querySelector('#om-devtools-option') as HTMLElement | null;
+    if (devtoolsItem) {
+      devtoolsItem.style.display = devToolsEnabled ? '' : 'none';
+    }
+  }).catch(() => { /* ignore */ });
 }
 
 export function hide(): void {

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -14,18 +14,21 @@ const modKey = isMac ? 'Cmd' : 'Ctrl';
 // ---- Init ----
 document.addEventListener('DOMContentLoaded', async () => {
   await loadSettings();
-  initSidebarNavigation();
-  initGeneralSettings();
-  initSearchSettings();
-  initCookieSettings();
-  initAdBlockerSettings();
-  initPopupSettings();
-  initDataRetentionSettings();
-  initUserAgentSettings();
-  initNetworkSettings();
-  initKeyboardShortcuts();
-  initDeveloperSettings();
-  initSettingsSearch();
+  const safeInit = (fn: () => void, name: string) => {
+    try { fn(); } catch (e) { console.error(`Failed to init ${name}:`, e); }
+  };
+  safeInit(initSidebarNavigation, 'sidebar');
+  safeInit(initGeneralSettings, 'general');
+  safeInit(initSearchSettings, 'search');
+  safeInit(initCookieSettings, 'cookies');
+  safeInit(initAdBlockerSettings, 'adblocker');
+  safeInit(initPopupSettings, 'popups');
+  safeInit(initDataRetentionSettings, 'data-retention');
+  safeInit(initUserAgentSettings, 'user-agent');
+  safeInit(initNetworkSettings, 'network');
+  safeInit(initKeyboardShortcuts, 'shortcuts');
+  safeInit(initDeveloperSettings, 'developer');
+  safeInit(initSettingsSearch, 'search-bar');
   createIcons({ icons });
 });
 
@@ -697,7 +700,8 @@ function initUserAgentSettings() {
   const preview = document.getElementById('ua-preview');
 
   // Set initial values
-  const defaultPreset = process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows';
+  const platform = (window as any).DataStoreAPI?.platform;
+  const defaultPreset = platform === 'darwin' ? 'chrome-mac' : platform === 'linux' ? 'chrome-linux' : 'chrome-windows';
   select.value = settings.userAgentPreset || defaultPreset;
   customInput.value = settings.userAgentCustomValue || '';
   customContainer.style.display = select.value === 'custom' ? '' : 'none';


### PR DESCRIPTION
## Summary
This PR enhances the browser settings system with better error handling during initialization and adds enforcement of the DevTools disabled policy across all windows.

## Key Changes

- **Settings Initialization Resilience**: Wrapped all settings initialization functions in a `safeInit` helper that catches and logs errors individually, preventing one failed initialization from blocking others.

- **DevTools Policy Enforcement**: Added `applyDevToolsPolicy()` method to automatically close any open DevTools windows when the DevTools setting is disabled, ensuring the policy is enforced across all web contents.

- **Platform Detection Fix**: Changed platform detection in user agent settings from `process.platform` (main process) to `window.DataStoreAPI?.platform` (renderer process), fixing incorrect platform detection in the renderer context.

- **Options Menu DevTools Visibility**: Updated the options menu to dynamically hide the "Developer Tools" option when DevTools is disabled in settings, providing better UX consistency.

## Implementation Details

- The `safeInit` wrapper uses try-catch to isolate initialization failures and logs them with descriptive names for easier debugging.
- DevTools policy is applied both during initial settings load and when settings are updated via the settings change listener.
- The options menu DevTools visibility check is performed asynchronously when the menu is shown to reflect the current settings state.

https://claude.ai/code/session_01FS3LGvyofFkRru2qnydXeY