### PR TITLE
Move IPC handler registration before window creation

### DIFF
--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -91,6 +91,12 @@ export abstract class AppWindowManager {
     const startupSettings: BrowserSettings = { ...DEFAULT_BROWSER_SETTINGS, ...stored };
     const startupMode = startupSettings.startupMode;
 
+    // Register IPC handlers before any BrowserWindow is created so renderer
+    // processes (which invoke handlers like UPDATE_BROWSER_VIEW_BOUNDS on
+    // DOMContentLoaded) cannot race ahead of handler registration while this
+    // method awaits session restoration or window readiness below.
+    AppWindowManager.initIPCHandlers();
+
     if (startupMode === 'continue') {
       const sessionRestored = await SessionManager.restoreSession();
       if (!sessionRestored) {
@@ -113,7 +119,6 @@ export abstract class AppWindowManager {
     } else {
       AppWindowManager.createWindow();
     }
-    AppWindowManager.initIPCHandlers();
     AppMenuManager.init();
     AppWindowManager.startHibernationChecker();
     SessionManager.startPeriodicSave();


### PR DESCRIPTION
## Summary
This change reorders the initialization sequence in the AppWindowManager to register IPC handlers before any BrowserWindow is created, preventing race conditions between renderer processes and handler registration.

## Key Changes
- Moved `AppWindowManager.initIPCHandlers()` call to execute before session restoration and window creation logic
- Previously, IPC handlers were registered after window creation, which could allow renderer processes to invoke handlers (like `UPDATE_BROWSER_VIEW_BOUNDS` on `DOMContentLoaded`) before the handlers were ready

## Implementation Details
The IPC handler registration is now the first operation in the startup sequence, ensuring that when renderer processes start and attempt to communicate with the main process, the necessary handlers are already in place. This eliminates a potential race condition where renderer processes could invoke IPC handlers during their initialization while the main process was still awaiting session restoration or window readiness.

https://claude.ai/code/session_01J25Fss5WpDrYeZy67W8nd6