### PR TITLE
Fix blog card link styling and hover state

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -234,7 +234,7 @@
   gap: 1.5rem;
 }
 
-.blog-card {
+a.blog-card {
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
@@ -246,10 +246,11 @@
   flex-direction: column;
 }
 
-.blog-card:hover {
+a.blog-card:hover {
   border-color: var(--vp-c-brand-1);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   transform: translateY(-2px);
+  text-decoration: none;
 }
 
 .blog-card .blog-tag {


### PR DESCRIPTION
## Summary
Updated the blog card styling to properly target anchor elements and improve the hover state appearance.

## Key Changes
- Changed `.blog-card` selector to `a.blog-card` to specifically target blog cards that are links
- Updated `.blog-card:hover` to `a.blog-card:hover` to match the new selector
- Added `text-decoration: none` to the hover state to remove underline on link interaction

## Implementation Details
These changes ensure that blog card styling is applied only to anchor elements and prevent the default link underline from appearing on hover, maintaining a cleaner visual appearance while the card transforms and shadow effects are applied.

https://claude.ai/code/session_012Fbgvssv6k4xYc5wAULWeW