### PR TITLE
Implement bot-detection mitigation for Cloudflare Turnstile

### DIFF
--- a/src/main/browser/ua-switcher.ts
+++ b/src/main/browser/ua-switcher.ts
@@ -1,0 +1,109 @@
+import { app } from "electron";
+
+/*
+ * User-Agent and Client-Hints normalization.
+ *
+ * Cloudflare Turnstile (and similar bot-detection systems) cross-check the
+ * User-Agent header against the SEC-CH-UA client-hint headers. Electron's
+ * default User-Agent contains "Electron/..." and the app name, and Chromium
+ * sends SEC-CH-UA headers that reflect Electron's exact Chromium version
+ * (e.g. "133.0.6943.53"). That combination is trivially detectable.
+ *
+ * This module implements the same mitigation used by Min Browser
+ * (https://github.com/minbrowser/min/blob/master/main/UASwitcher.js):
+ *
+ *   1. Rewrite `app.userAgentFallback` to strip the "Electron/..." and
+ *      "nav0-browser/..." tokens and zero out the Chrome minor/patch version
+ *      numbers (matching Chrome's own User-Agent reduction).
+ *   2. Inject SEC-CH-UA / SEC-CH-UA-Mobile / SEC-CH-UA-Platform request
+ *      headers that align with whatever User-Agent is actually being sent on
+ *      the wire (so Turnstile sees a consistent Chrome profile).
+ */
+
+function reduceChromeVersion(version: string): string {
+  // "133.0.6943.53" -> "133.0.0.0" (Chrome UA-Reduction form)
+  return version
+    .split(".")
+    .map((part, idx) => (idx === 0 ? part : "0"))
+    .join(".");
+}
+
+/**
+ * Normalize `app.userAgentFallback` so webContents created without an explicit
+ * UA override do not leak the "Electron/x.y.z" / "nav0-browser/x.y.z" tokens.
+ * Must be called before any BrowserWindow/WebContentsView is created.
+ */
+export function configureUserAgentFallback(): void {
+  const defaultUA = app.userAgentFallback || "";
+  const chromeVersion = process.versions.chrome;
+
+  let newUA = defaultUA
+    .replace(/nav0-browser\/\S+\s?/i, "")
+    .replace(/Nav0\/\S+\s?/i, "")
+    .replace(/Electron\/\S+\s?/, "");
+
+  if (chromeVersion) {
+    newUA = newUA.replace(chromeVersion, reduceChromeVersion(chromeVersion));
+  }
+
+  app.userAgentFallback = newUA.trim();
+}
+
+function platformFromUA(ua: string): string {
+  if (/Windows/.test(ua)) return '"Windows"';
+  if (/Macintosh|Mac OS X/.test(ua)) return '"macOS"';
+  if (/Android/.test(ua)) return '"Android"';
+  if (/CrOS/.test(ua)) return '"Chrome OS"';
+  if (/Linux/.test(ua)) return '"Linux"';
+  return '"Unknown"';
+}
+
+/**
+ * Mutates the given request-header map so SEC-CH-UA* headers are consistent
+ * with the User-Agent in the same map. This mirrors what a real Chrome/Edge
+ * browser sends and is what Cloudflare Turnstile cross-checks.
+ *
+ * - For Chrome/Edge UAs: writes matching brand/version client hints.
+ * - For Firefox/Safari UAs: strips any SEC-CH-UA headers Chromium may have
+ *   auto-populated, since those browsers do not send them.
+ */
+export function applyClientHints(headers: Record<string, string | string[]>): void {
+  const rawUA = headers["User-Agent"] ?? headers["user-agent"] ?? "";
+  const ua = Array.isArray(rawUA) ? rawUA[0] : rawUA;
+  if (!ua) return;
+
+  const isFirefox = /Firefox\//.test(ua);
+  const isSafariOnly = /Safari\//.test(ua) && !/Chrome\/|Chromium\/|Edg\//.test(ua);
+
+  if (isFirefox || isSafariOnly) {
+    delete headers["sec-ch-ua"];
+    delete headers["Sec-CH-UA"];
+    delete headers["sec-ch-ua-mobile"];
+    delete headers["Sec-CH-UA-Mobile"];
+    delete headers["sec-ch-ua-platform"];
+    delete headers["Sec-CH-UA-Platform"];
+    return;
+  }
+
+  const chromeMatch = ua.match(/Chrome\/(\d+)/);
+  if (!chromeMatch) return;
+  const chromeMajor = chromeMatch[1];
+  const edgeMatch = ua.match(/Edg\/(\d+)/);
+
+  let brandHeader: string;
+  if (edgeMatch) {
+    const edgeMajor = edgeMatch[1];
+    brandHeader = `"Microsoft Edge";v="${edgeMajor}", "Chromium";v="${chromeMajor}", "Not.A/Brand";v="99"`;
+  } else {
+    brandHeader = `"Google Chrome";v="${chromeMajor}", "Chromium";v="${chromeMajor}", "Not.A/Brand";v="99"`;
+  }
+
+  // Delete any pre-existing casing variants to avoid duplicates in the final request.
+  delete headers["Sec-CH-UA"];
+  delete headers["Sec-CH-UA-Mobile"];
+  delete headers["Sec-CH-UA-Platform"];
+
+  headers["sec-ch-ua"] = brandHeader;
+  headers["sec-ch-ua-mobile"] = "?0";
+  headers["sec-ch-ua-platform"] = platformFromUA(ua);
+}

--- a/src/main/browser/ua-switcher.ts
+++ b/src/main/browser/ua-switcher.ts
@@ -107,3 +107,37 @@ export function applyClientHints(headers: Record<string, string | string[]>): vo
   headers["sec-ch-ua-mobile"] = "?0";
   headers["sec-ch-ua-platform"] = platformFromUA(ua);
 }
+
+/**
+ * Rewrite the `Chrome/x.y.z.w` (and, if present, `Edg/x.y.z.w`) token in a UA
+ * preset so its major/minor version matches Electron's ACTUAL Chromium
+ * version, with the remaining parts zeroed (Chrome UA-Reduction form).
+ *
+ * Why this is necessary: the nav0 UA presets hard-code a Chrome major like
+ * `Chrome/136.0.0.0`, but Electron ships its own Chromium (e.g. 134). If we
+ * call `session.setUserAgent()` with the preset verbatim, then:
+ *   - `navigator.userAgent` reports Chrome 136 (from our override)
+ *   - `navigator.userAgentData.brands` reports Chromium 134 (from Electron's
+ *     real Chromium — this is NOT changeable from the main process)
+ * Cloudflare Turnstile reads both JS APIs and flags the drift. By substituting
+ * Electron's real Chromium major into the preset string before calling
+ * `setUserAgent`, the UA string, userAgentData, and our SEC-CH-UA header all
+ * agree on the Chrome major version. Min Browser sidesteps this by never
+ * overriding the UA at all; we can't do that without losing the preset
+ * feature, so we align versions instead.
+ *
+ * Platform masquerading (e.g. "Chrome on macOS" from Windows) is preserved —
+ * only the Chrome version number changes.
+ *
+ * Pass-through for non-Chrome presets (Firefox / Safari): the regex simply
+ * doesn't match, and the UA is returned unchanged.
+ */
+export function alignUAWithRealChromeVersion(ua: string): string {
+  const chromeVersion = process.versions.chrome;
+  if (!ua || !chromeVersion) return ua;
+  const reduced = reduceChromeVersion(chromeVersion);
+  // Replaces "Chrome/<anything up to whitespace>" — same for Edg/.
+  return ua
+    .replace(/Chrome\/\S+/g, `Chrome/${reduced}`)
+    .replace(/Edg\/\S+/g, `Edg/${reduced}`);
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,14 @@ import { DataStoreManager } from './database/data-store-manager';
 import { DownloadManager } from './browser/download-manager';
 import { SessionManager } from './browser/session-manager';
 import { SettingsEnforcer } from './settings/settings-enforcer';
+import { configureUserAgentFallback } from './browser/ua-switcher';
 import { startTestControlServer } from './test-control-server';
+
+// Strip "Electron/..." and "nav0-browser/..." tokens from the default User-Agent
+// and zero Chrome minor-version numbers so sites that fingerprint the UA (e.g.
+// Cloudflare Turnstile) don't flag webContents we haven't explicitly configured.
+// Must run before any BrowserWindow / WebContentsView is created.
+configureUserAgentFallback();
 
 // Disable Chromium features that trigger macOS "Local Network" permission dialog.
 // These features use mDNS/Bonjour for device discovery, which is unnecessary for

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -13,7 +13,8 @@ export abstract class SettingsEnforcer {
   public static async init() {
     SettingsEnforcer.initIPCHandlers();
     const settings = SettingsEnforcer.getSettings();
-    SettingsEnforcer.applyCookiePolicy(settings);
+    SettingsEnforcer.applyRequestHeaderPolicy(settings);
+    SettingsEnforcer.applyResponseHeaderPolicy(settings);
     SettingsEnforcer.applyProxySettings(settings);
     SettingsEnforcer.applyUserAgent(settings);
     SettingsEnforcer.applyAdBlocker(settings);
@@ -43,7 +44,8 @@ export abstract class SettingsEnforcer {
   private static initIPCHandlers() {
     ipcMain.handle(RendererToMainEventsForBrowserIPC.APPLY_SETTINGS, async () => {
       const settings = SettingsEnforcer.getSettings();
-      SettingsEnforcer.applyCookiePolicy(settings);
+      SettingsEnforcer.applyRequestHeaderPolicy(settings);
+      SettingsEnforcer.applyResponseHeaderPolicy(settings);
       SettingsEnforcer.applyProxySettings(settings);
       SettingsEnforcer.applyUserAgent(settings);
       SettingsEnforcer.applyAdBlocker(settings);
@@ -74,38 +76,98 @@ export abstract class SettingsEnforcer {
     });
   }
 
-  // ---- Cookie Policy Enforcement ----
-  private static applyCookiePolicy(settings: BrowserSettings) {
+  // ---- Request Header Policy ----
+  // Single onBeforeSendHeaders listener per browsing/private session. Electron
+  // only allows one listener per session, so the three concerns below are
+  // consolidated:
+  //   1. Cookie stripping when blockAllCookies is on (browsing session only,
+  //      matching pre-existing behavior).
+  //   2. SEC-CH-UA Client Hints alignment with the configured User-Agent so
+  //      Cloudflare Turnstile (and similar) don't flag the Electron/Chromium
+  //      version mismatch. See src/main/browser/ua-switcher.ts.
+  //   3. A per-request User-Agent override to a Firefox string for
+  //      accounts.google.com, which sidesteps Google's Chromium/Electron
+  //      embedded-browser block. Technique borrowed from Min browser:
+  //      https://github.com/minbrowser/min/blob/master/main/UASwitcher.js
+  private static applyRequestHeaderPolicy(settings: BrowserSettings) {
     const browsingSes = session.fromPartition('persist:browsertabs');
     const privateSes = session.fromPartition('persist:private');
+    const stripCookies = settings.blockAllCookies;
+    const preset = SettingsEnforcer.resolveUserAgentPreset(settings);
+    // Respect an explicit custom UA — don't override it for Google sign-in.
+    const hasCustomUserAgent = preset === 'custom' && !!settings.userAgentCustomValue;
 
-    // Reset listeners on both partitions so we can reattach cleanly.
-    browsingSes.webRequest.onBeforeSendHeaders(null);
-    browsingSes.webRequest.onHeadersReceived(null);
-    privateSes.webRequest.onBeforeSendHeaders(null);
-    privateSes.webRequest.onHeadersReceived(null);
+    const sessionsWithCookieStripping: Array<[Electron.Session, boolean]> = [
+      [browsingSes, true],
+      [privateSes, false],
+    ];
 
-    // Always attach onBeforeSendHeaders on both partitions so SEC-CH-UA
-    // client hints stay aligned with the configured User-Agent (see
-    // ua-switcher.ts). Cloudflare Turnstile cross-checks the two, so if
-    // they drift (because Chromium auto-populates SEC-CH-UA from its own
-    // version while we've overridden the UA) the challenge fails.
-    const makeBeforeSendHeaders = (stripCookie: boolean) => {
-      return (details: Electron.OnBeforeSendHeadersListenerDetails, callback: (response: Electron.BeforeSendResponse) => void) => {
+    for (const [ses, allowCookieStripping] of sessionsWithCookieStripping) {
+      // Clear any previous listener; Electron only allows one per session.
+      ses.webRequest.onBeforeSendHeaders(null);
+
+      ses.webRequest.onBeforeSendHeaders((details, callback) => {
         const headers = { ...details.requestHeaders };
-        applyClientHints(headers);
-        if (stripCookie) {
+
+        if (allowCookieStripping && stripCookies) {
           delete headers['Cookie'];
+          delete headers['cookie'];
         }
+
+        // Align SEC-CH-UA Client Hints with whatever User-Agent is about to
+        // go out, so Turnstile's header-consistency check passes.
+        applyClientHints(headers);
+
+        // Google sign-in workaround: Google serves a different (Firefox-path)
+        // sign-in page when the UA claims Firefox, and that path does not run
+        // the Chromium/Electron embedded-browser detection. Override only for
+        // accounts.google.com so the rest of the session keeps the user's
+        // chosen preset.
+        let isGoogleSignIn = false;
+        try {
+          isGoogleSignIn = new URL(details.url).hostname === 'accounts.google.com';
+        } catch { /* ignore */ }
+
+        if (isGoogleSignIn && !hasCustomUserAgent) {
+          headers['User-Agent'] = SettingsEnforcer.getFirefoxUA();
+          // Firefox doesn't send Client Hints — strip every sec-ch-ua* header
+          // that applyClientHints just set.
+          for (const key of Object.keys(headers)) {
+            if (key.toLowerCase().startsWith('sec-ch-ua')) {
+              delete headers[key];
+            }
+          }
+        }
+
         callback({ requestHeaders: headers });
-      };
+      });
+    }
+  }
+
+  // Firefox UA generator (adapted from Min browser's UASwitcher.js).
+  // Estimates the current Firefox major version: v91 was released on
+  // 2021-08-10, and new major versions ship roughly every 4.1 weeks.
+  private static getFirefoxUA(): string {
+    const rootUAs = {
+      mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
+      windows: 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
+      linux: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
     };
-    browsingSes.webRequest.onBeforeSendHeaders(makeBeforeSendHeaders(settings.blockAllCookies));
-    privateSes.webRequest.onBeforeSendHeaders(makeBeforeSendHeaders(false));
+    let rootUA: string;
+    if (process.platform === 'win32') rootUA = rootUAs.windows;
+    else if (process.platform === 'darwin') rootUA = rootUAs.mac;
+    else rootUA = rootUAs.linux;
+    const fxVersion = 91 + Math.floor((Date.now() - 1628553600000) / (4.1 * 7 * 24 * 60 * 60 * 1000));
+    return rootUA.replace(/FXVERSION/g, String(fxVersion));
+  }
+
+  // ---- Response Header Policy (Cookie Jar Enforcement) ----
+  private static applyResponseHeaderPolicy(settings: BrowserSettings) {
+    const ses = session.fromPartition('persist:browsertabs');
+    ses.webRequest.onHeadersReceived(null);
 
     if (settings.blockAllCookies) {
-      // Block all cookies (response side) on the browsing partition.
-      browsingSes.webRequest.onHeadersReceived((details, callback) => {
+      ses.webRequest.onHeadersReceived((details, callback) => {
         const headers = { ...details.responseHeaders };
         delete headers['set-cookie'];
         delete headers['Set-Cookie'];
@@ -114,7 +176,6 @@ export abstract class SettingsEnforcer {
       return;
     }
 
-    const ses = browsingSes;
     if (settings.cookiePolicy === 'block-all-third-party' || settings.cookiePolicy === 'block-with-exceptions') {
       ses.webRequest.onHeadersReceived((details, callback) => {
         if (!details.responseHeaders) {
@@ -219,11 +280,15 @@ export abstract class SettingsEnforcer {
   }
 
   // ---- User Agent ----
+  private static resolveUserAgentPreset(settings: BrowserSettings): string {
+    return settings.userAgentPreset || (process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows');
+  }
+
   private static applyUserAgent(settings: BrowserSettings) {
     const browsingSes = session.fromPartition('persist:browsertabs');
     const privateSes = session.fromPartition('persist:private');
 
-    const preset = settings.userAgentPreset || (process.platform === 'darwin' ? 'chrome-mac' : process.platform === 'linux' ? 'chrome-linux' : 'chrome-windows');
+    const preset = SettingsEnforcer.resolveUserAgentPreset(settings);
 
     let userAgent: string;
 

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -4,7 +4,7 @@ import { DataStoreManager } from "../database/data-store-manager";
 import { DatabaseManager } from "../database/database-manager";
 import { BrowserSettings, DEFAULT_BROWSER_SETTINGS, USER_AGENT_PRESETS } from "../../types/settings-types";
 import { AD_BLOCK_DOMAINS, AD_URL_PATTERNS } from "../ad-blocker/ad-block-lists";
-import { applyClientHints } from "../browser/ua-switcher";
+import { applyClientHints, alignUAWithRealChromeVersion } from "../browser/ua-switcher";
 
 export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
@@ -298,6 +298,15 @@ export abstract class SettingsEnforcer {
     } else {
       userAgent = USER_AGENT_PRESETS[preset]?.value || '';
       if (!userAgent) return;
+    }
+
+    // For built-in Chrome/Edge presets, substitute Electron's real Chromium
+    // major version into the UA so navigator.userAgent and the unchangeable
+    // navigator.userAgentData.brands agree. Turnstile checks both. See
+    // ua-switcher.ts:alignUAWithRealChromeVersion for the full rationale.
+    // (Custom UAs are user-authored and left untouched.)
+    if (preset !== 'custom') {
+      userAgent = alignUAWithRealChromeVersion(userAgent);
     }
 
     const acceptLanguages = 'en-US,en;q=0.9';

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -4,6 +4,7 @@ import { DataStoreManager } from "../database/data-store-manager";
 import { DatabaseManager } from "../database/database-manager";
 import { BrowserSettings, DEFAULT_BROWSER_SETTINGS, USER_AGENT_PRESETS } from "../../types/settings-types";
 import { AD_BLOCK_DOMAINS, AD_URL_PATTERNS } from "../ad-blocker/ad-block-lists";
+import { applyClientHints } from "../browser/ua-switcher";
 
 export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
@@ -75,19 +76,36 @@ export abstract class SettingsEnforcer {
 
   // ---- Cookie Policy Enforcement ----
   private static applyCookiePolicy(settings: BrowserSettings) {
-    const ses = session.fromPartition('persist:browsertabs');
-    // Remove existing listeners to prevent duplicates
-    ses.webRequest.onBeforeSendHeaders(null);
-    ses.webRequest.onHeadersReceived(null);
+    const browsingSes = session.fromPartition('persist:browsertabs');
+    const privateSes = session.fromPartition('persist:private');
+
+    // Reset listeners on both partitions so we can reattach cleanly.
+    browsingSes.webRequest.onBeforeSendHeaders(null);
+    browsingSes.webRequest.onHeadersReceived(null);
+    privateSes.webRequest.onBeforeSendHeaders(null);
+    privateSes.webRequest.onHeadersReceived(null);
+
+    // Always attach onBeforeSendHeaders on both partitions so SEC-CH-UA
+    // client hints stay aligned with the configured User-Agent (see
+    // ua-switcher.ts). Cloudflare Turnstile cross-checks the two, so if
+    // they drift (because Chromium auto-populates SEC-CH-UA from its own
+    // version while we've overridden the UA) the challenge fails.
+    const makeBeforeSendHeaders = (stripCookie: boolean) => {
+      return (details: Electron.OnBeforeSendHeadersListenerDetails, callback: (response: Electron.BeforeSendResponse) => void) => {
+        const headers = { ...details.requestHeaders };
+        applyClientHints(headers);
+        if (stripCookie) {
+          delete headers['Cookie'];
+        }
+        callback({ requestHeaders: headers });
+      };
+    };
+    browsingSes.webRequest.onBeforeSendHeaders(makeBeforeSendHeaders(settings.blockAllCookies));
+    privateSes.webRequest.onBeforeSendHeaders(makeBeforeSendHeaders(false));
 
     if (settings.blockAllCookies) {
-      // Block all cookies
-      ses.webRequest.onBeforeSendHeaders((details, callback) => {
-        const headers = { ...details.requestHeaders };
-        delete headers['Cookie'];
-        callback({ requestHeaders: headers });
-      });
-      ses.webRequest.onHeadersReceived((details, callback) => {
+      // Block all cookies (response side) on the browsing partition.
+      browsingSes.webRequest.onHeadersReceived((details, callback) => {
         const headers = { ...details.responseHeaders };
         delete headers['set-cookie'];
         delete headers['Set-Cookie'];
@@ -96,6 +114,7 @@ export abstract class SettingsEnforcer {
       return;
     }
 
+    const ses = browsingSes;
     if (settings.cookiePolicy === 'block-all-third-party' || settings.cookiePolicy === 'block-with-exceptions') {
       ses.webRequest.onHeadersReceived((details, callback) => {
         if (!details.responseHeaders) {

--- a/src/preload/web-content-preload.ts
+++ b/src/preload/web-content-preload.ts
@@ -12,7 +12,7 @@
  * process via IPC (bypassing renderer CSP / network restrictions).
  */
 
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, webFrame } from 'electron';
 
 // Expose a function the main-world polyfill can call to get IP geolocation
 // from the main process (uses Electron net.fetch, immune to page CSP).
@@ -365,3 +365,64 @@ observer.observe(document, { childList: true, subtree: true });
 if (document.documentElement) {
   injectPolyfill();
 }
+
+// ─── window.chrome.runtime polyfill for Google domains ────────────────
+// Many Google properties (accounts.google.com sign-in, Gmail, etc.) probe
+// `window.chrome.runtime.connect` to confirm they're running in real Chrome.
+// In Electron `window.chrome` is undefined, so the check fails and Google
+// blocks sign-in or refuses to load — even when the User-Agent is a
+// perfectly-aligned Chrome string. Injecting a minimal stub satisfies the
+// probe. Same fix Min Browser applies in js/preload/siteUnbreak.js.
+//
+// Hangouts and Drive are excluded because Min found defining window.chrome
+// breaks them (Hangouts tries to talk to a non-existent extension; Drive's
+// file viewer behaves similarly). See:
+// https://github.com/minbrowser/min/issues/1051 and the comments in
+// siteUnbreak.js.
+//
+// Use webFrame.executeJavaScript instead of an inline <script> blob: Google
+// ships a strict CSP via response header that the preload can't inspect
+// (only meta CSP is visible from here), so the existing injectPolyfill
+// blob-URL path may be blocked. webFrame.executeJavaScript runs in the
+// page's main world and bypasses CSP entirely.
+function injectGoogleChromeRuntimeStub(): void {
+  try {
+    const host = window.location.hostname;
+    const isGoogleHost =
+      (host === 'google.com' || host.endsWith('.google.com')) &&
+      host !== 'hangouts.google.com' &&
+      host !== 'drive.google.com';
+    if (!isGoogleHost) return;
+
+    const code = `
+      (function () {
+        if (window.chrome && window.chrome.runtime) return;
+        var noop = function () {};
+        var stubPort = {
+          name: '',
+          onMessage: { addListener: noop, removeListener: noop, hasListener: function () { return false; } },
+          onDisconnect: { addListener: noop, removeListener: noop, hasListener: function () { return false; } },
+          postMessage: noop,
+          disconnect: noop,
+        };
+        var runtime = {
+          id: undefined,
+          connect: function () { return stubPort; },
+          sendMessage: function () {},
+          onMessage: { addListener: noop, removeListener: noop, hasListener: function () { return false; } },
+          onConnect: { addListener: noop, removeListener: noop, hasListener: function () { return false; } },
+        };
+        if (!window.chrome) {
+          Object.defineProperty(window, 'chrome', { value: { runtime: runtime }, writable: true, configurable: true });
+        } else {
+          window.chrome.runtime = runtime;
+        }
+      })();
+    `;
+    webFrame.executeJavaScript(code).catch(() => { /* ignore */ });
+  } catch {
+    // Ignore — preload should never throw into the page.
+  }
+}
+
+injectGoogleChromeRuntimeStub();


### PR DESCRIPTION
## Summary
This PR implements comprehensive bot-detection mitigation to prevent Cloudflare Turnstile and similar systems from flagging the browser as an automated Electron client. The changes align the User-Agent string, Client Hints headers, and navigator APIs, and add a Google sign-in workaround to bypass embedded-browser detection.

## Key Changes

- **New UA-Switcher Module** (`src/main/browser/ua-switcher.ts`):
  - `configureUserAgentFallback()`: Strips "Electron/..." and "nav0-browser/..." tokens from the default User-Agent and zeros Chrome minor/patch versions before any windows are created
  - `applyClientHints()`: Injects SEC-CH-UA* headers that match the configured User-Agent so Turnstile's header-consistency check passes
  - `alignUAWithRealChromeVersion()`: Substitutes Electron's real Chromium major version into UA presets so `navigator.userAgent` and the unchangeable `navigator.userAgentData.brands` agree

- **Settings Enforcer Refactoring** (`src/main/settings/settings-enforcer.ts`):
  - Split cookie policy into separate request and response header handlers (`applyRequestHeaderPolicy` / `applyResponseHeaderPolicy`)
  - Consolidated three concerns in `applyRequestHeaderPolicy`: cookie stripping, Client Hints alignment, and per-request UA override for Google sign-in
  - Added `getFirefoxUA()` to generate a dynamic Firefox User-Agent string for accounts.google.com, bypassing Google's Chromium/Electron embedded-browser block
  - Extracted `resolveUserAgentPreset()` helper for cleaner code reuse

- **Preload Script Enhancement** (`src/preload/web-content-preload.ts`):
  - Added `injectGoogleChromeRuntimeStub()` to define a minimal `window.chrome.runtime` stub on Google domains (except Hangouts and Drive, which break with it)
  - Uses `webFrame.executeJavaScript()` to bypass strict CSP headers that Google sends

- **Main Process Initialization** (`src/main/index.ts`):
  - Call `configureUserAgentFallback()` at startup, before any windows are created

## Implementation Details

- The mitigation is based on techniques from [Min Browser](https://github.com/minbrowser/min/blob/master/main/UASwitcher.js)
- Chrome UA-Reduction form (zeroing minor/patch versions) matches Chrome's own User-Agent reduction strategy
- Google sign-in override only applies to `accounts.google.com` and respects custom User-Agent settings
- Firefox version estimation uses a formula based on the v91 release date (2021-08-10) and ~4.1 week release cycles
- Client Hints are stripped entirely for Firefox/Safari UAs since those browsers don't send them

https://claude.ai/code/session_01YTEen276CLoovLuRJfpsme