### PR TITLE
Release v0.2.2: Turnstile, Chrome pinning, and Google fixes

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,10 +10,18 @@ What's new in every release of Nav0 Browser.
 ---
 
 <div class="release-list-item">
+  <a href="/releases/v0.2.2">
+    <h2>v0.2.2</h2>
+  </a>
+  <div class="release-meta">April 17, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Cloudflare Turnstile compatibility, Chrome version pinning to Electron's real Chromium, and Google sign-in and Gmail fixes via Firefox UA swap and a minimal window.chrome.runtime stub.</p>
+</div>
+
+<div class="release-list-item">
   <a href="/releases/v0.2.1">
     <h2>v0.2.1</h2>
   </a>
-  <div class="release-meta">April 14, 2026 <span class="release-badge latest">Latest</span></div>
+  <div class="release-meta">April 14, 2026</div>
   <p class="release-excerpt">Permissions settings page, configurable downloads location, "On startup" options, session restore for non-private windows, expanded website categories, and assorted settings and startup bug fixes.</p>
 </div>
 

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,12 +1,9 @@
 ---
 title: "v0.2.1"
 date: 2026-04-14
-badge: Latest
 ---
 
 # v0.2.1
-
-<span class="release-badge latest">Latest</span>
 
 <div class="release-date-meta">April 14, 2026</div>
 

--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,22 @@
+---
+title: "v0.2.2"
+date: 2026-04-17
+badge: Latest
+---
+
+# v0.2.2
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">April 17, 2026</div>
+
+## Site Compatibility
+
+- **Cloudflare Turnstile Support** — align `SEC-CH-UA`, `SEC-CH-UA-Mobile`, and `SEC-CH-UA-Platform` headers with the overridden User-Agent so Turnstile challenges pass; strip Client Hints for Firefox and Safari presets
+- **Chrome Version Pinning** — substitute Electron's real Chromium major into the UA preset's `Chrome/` and `Edg/` tokens so `navigator.userAgent`, `navigator.userAgentData`, and outgoing `SEC-CH-UA` all agree
+- **Google Sign-In Fix** — swap in a Firefox User-Agent for `accounts.google.com` (and drop Client Hints for that host) so Google serves the Firefox sign-in path instead of blocking embedded-browser detection
+- **Gmail / Google Runtime Stub** — inject a minimal `window.chrome.runtime` stub on Google domains (excluding hangouts/drive) via the web-content preload so Google's "is this real Chrome?" probe succeeds
+
+## Improvements
+
+- **Header Policy Split** — split `applyCookiePolicy` into `applyRequestHeaderPolicy` + `applyResponseHeaderPolicy` so cookie stripping, Client Hints alignment, and host-specific UA overrides share the single `onBeforeSendHeaders` listener Electron allows per session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Nav0",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Nav0",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nav0",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
This PR releases v0.2.2 of Nav0 Browser, which introduces critical compatibility fixes for Cloudflare Turnstile, Chrome version pinning to match Electron's Chromium, and Google Sign-In/Gmail support through User-Agent and runtime stub injection.

## Key Changes
- **Version bump** — Updated package.json from v0.2.1 to v0.2.2
- **Release documentation** — Added v0.2.2 release notes documenting:
  - Cloudflare Turnstile support via Client Hints alignment with overridden User-Agent
  - Chrome version pinning to substitute Electron's real Chromium major version into UA presets
  - Google Sign-In fix using Firefox User-Agent swap for accounts.google.com
  - Gmail/Google runtime stub injection via `window.chrome.runtime` for embedded browser detection
  - Header policy refactoring that splits cookie and header handling into separate request/response listeners
- **Release index update** — Added v0.2.2 to the releases index page and moved the "Latest" badge from v0.2.1 to v0.2.2

## Notable Details
The release addresses a critical set of compatibility issues where embedded browser detection and Client Hints validation were causing failures on major Google services and Cloudflare's Turnstile. The header policy split consolidates multiple header-manipulation concerns into a single `onBeforeSendHeaders` listener per session, which is an Electron API constraint.

https://claude.ai/code/session_01GmGVGvm1db5NAmcxguqiti