### PR TITLE
Release v0.2.3: Dialogs, Auth, Screen Sharing & Installer

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,10 +10,18 @@ What's new in every release of Nav0 Browser.
 ---
 
 <div class="release-list-item">
+  <a href="/releases/v0.2.3">
+    <h2>v0.2.3</h2>
+  </a>
+  <div class="release-meta">April 21, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Blocking alert/confirm/prompt and basic-auth overlays, getDisplayMedia screen sharing with a dedicated picker, localhost and .local-style URL handling, main-process crash hardening, and a graceful installer prompt when Nav0 is already running.</p>
+</div>
+
+<div class="release-list-item">
   <a href="/releases/v0.2.2">
     <h2>v0.2.2</h2>
   </a>
-  <div class="release-meta">April 17, 2026 <span class="release-badge latest">Latest</span></div>
+  <div class="release-meta">April 17, 2026</div>
   <p class="release-excerpt">Cloudflare Turnstile compatibility, Chrome version pinning to Electron's real Chromium, and Google sign-in and Gmail fixes via Firefox UA swap and a minimal window.chrome.runtime stub.</p>
 </div>
 

--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,12 +1,9 @@
 ---
 title: "v0.2.2"
 date: 2026-04-17
-badge: Latest
 ---
 
 # v0.2.2
-
-<span class="release-badge latest">Latest</span>
 
 <div class="release-date-meta">April 17, 2026</div>
 

--- a/docs/releases/v0.2.3.md
+++ b/docs/releases/v0.2.3.md
@@ -1,0 +1,38 @@
+---
+title: "v0.2.3"
+date: 2026-04-21
+badge: Latest
+---
+
+# v0.2.3
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">April 21, 2026</div>
+
+## Dialogs & Authentication
+
+- **Blocking Alert / Confirm / Prompt** — `window.alert`, `window.confirm`, and `window.prompt` now route through the unified overlay layer via a sync IPC bridge, so pages block as the spec requires instead of silently resolving
+- **Basic & Proxy Auth Overlay** — HTTP basic-auth and proxy-auth challenges are collected through an in-browser overlay and resolved (or cancelled) on the main process, replacing Electron's default prompt
+- **Tab-Aware Dialogs** — a background tab that triggers an alert or auth prompt is foregrounded first so the dialog is shown in the context of the page that spawned it
+- **Safe Cancellation** — outstanding dialogs and auth prompts are cancelled when the owning window closes so awaited promises and network callbacks never hang
+
+## Screen Sharing
+
+- **getDisplayMedia Support** — `session.setDisplayMediaRequestHandler` is wired up so screen and window sharing on Meet, Zoom, and Teams stops silently failing
+- **Source Picker UI** — a dedicated picker renderer (`display-capture-picker`) lists available screens and windows via `desktopCapturer.getSources`, replacing the previous inline `data:` URL approach and following the same webpack entry / preload pattern as other built-in pages
+- **Concurrent Request Isolation** — per-request state is keyed on the picker's `webContents` id so overlapping share requests stay independent
+
+## Navigation
+
+- **Localhost & Local Network URLs** — bare inputs like `localhost:3000`, `127.0.0.1`, `[::1]`, `0.0.0.0`, and `.local` / `.test` / `.lan` / `.internal` / `.home.arpa` hosts are now treated as direct HTTP navigations instead of being sent to the search engine or force-upgraded to HTTPS
+
+## Stability & Security
+
+- **Main-Process Crash Hardening** — process-level `uncaughtException` and `unhandledRejection` handlers surface a throttled error dialog instead of bringing the whole browser down on a stray error
+- **Top-Frame Permission Scoping** — permission prompts and persistent decisions for sub-frame requests are now keyed to the top-frame origin, while still requiring both the top frame and the iframe to be on secure origins
+
+## Installer
+
+- **Graceful Update When Running** — the one-line curl installer no longer aborts when Nav0 is running. It prompts on the TTY, quits Nav0 via AppleScript (escalating to `SIGTERM`/`SIGKILL` if needed), and relaunches the new build. Set `NAV0_ASSUME_YES=1` to skip the prompt for automation
+- **Tighter Process Detection** — detection uses `pgrep -x Nav0` with a bundle-path fallback, so Electron helper and renderer processes no longer false-positive

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Nav0",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Nav0",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nav0",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
This PR releases v0.2.3 of Nav0 Browser, adding support for blocking dialogs and authentication overlays, screen sharing via `getDisplayMedia`, improved URL handling for localhost and local network addresses, main-process crash hardening, and a graceful installer update flow.

## Changes Made

- **Version bump** — Updated `package.json` from v0.2.2 to v0.2.3
- **Release documentation** — Created comprehensive v0.2.3 release notes documenting:
  - Blocking alert/confirm/prompt dialogs routed through unified overlay layer
  - Basic and proxy authentication overlays with tab-aware foreground behavior
  - `getDisplayMedia` support with dedicated source picker UI
  - Localhost and local network URL handling (`.local`, `.test`, `.lan`, `.internal`, `.home.arpa`)
  - Main-process crash hardening with uncaught exception/rejection handlers
  - Top-frame permission scoping for sub-frame requests
  - Graceful installer updates with TTY prompts and process detection improvements
- **Release index update** — Added v0.2.3 to the releases index page and moved the "Latest" badge from v0.2.2 to v0.2.3
- **v0.2.2 cleanup** — Removed "Latest" badge and metadata from v0.2.2 release notes

## Notable Details

The release notes follow the established documentation pattern with categorized feature sections (Dialogs & Authentication, Screen Sharing, Navigation, Stability & Security, Installer) and provide implementation-level details about how each feature works (e.g., sync IPC bridge for dialogs, per-request state keying for concurrent display capture requests, bundle-path fallback for process detection).

https://claude.ai/code/session_016wbSiJDHrYE1VtsXg2aaBM