### PR TITLE
Add favicon display to permission manager settings

### DIFF
--- a/src/main/browser/permission-manager.ts
+++ b/src/main/browser/permission-manager.ts
@@ -31,6 +31,7 @@ export interface PermissionRecord {
   decision: string;
   createdAt: string;
   lastAccessedAt: string;
+  faviconUrl?: string | null;
 }
 
 // Callback type for showing/hiding the prompt UI
@@ -528,13 +529,21 @@ export class PermissionManager {
   static getAllPersistentPermissions(searchTerm?: string): PermissionRecord[] {
     if (!PermissionManager.db) return [];
     try {
+      const baseSelect = `
+        SELECT p.*,
+          (SELECT h.faviconUrl FROM browsingHistory h
+           WHERE h.faviconUrl IS NOT NULL
+             AND (h.url = p.origin OR h.url LIKE p.origin || '/%')
+           ORDER BY h.createdDate DESC LIMIT 1) AS faviconUrl
+        FROM site_permission p
+      `;
       if (searchTerm) {
         return PermissionManager.db.prepare(
-          'SELECT * FROM site_permission WHERE origin LIKE ? OR permissionType LIKE ? ORDER BY origin, permissionType'
+          `${baseSelect} WHERE p.origin LIKE ? OR p.permissionType LIKE ? ORDER BY p.origin, p.permissionType`
         ).all(`%${searchTerm}%`, `%${searchTerm}%`) as PermissionRecord[];
       }
       return PermissionManager.db.prepare(
-        'SELECT * FROM site_permission ORDER BY origin, permissionType'
+        `${baseSelect} ORDER BY p.origin, p.permissionType`
       ).all() as PermissionRecord[];
     } catch {
       return [];

--- a/src/renderer/pages/browser-settings/index.css
+++ b/src/renderer/pages/browser-settings/index.css
@@ -1287,7 +1287,7 @@
 .permission-origin-title {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: 10px;
   min-width: 0;
 }
 
@@ -1295,8 +1295,9 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  border-radius: 2px;
+  border-radius: 3px;
   object-fit: contain;
+  color: var(--n0-text-2);
 }
 
 .permission-origin-name {

--- a/src/renderer/pages/browser-settings/index.css
+++ b/src/renderer/pages/browser-settings/index.css
@@ -724,6 +724,21 @@
   border-bottom: 1px solid var(--border-color);
 }
 
+.permission-origin-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 0;
+}
+
+.permission-origin-favicon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  object-fit: contain;
+}
+
 .permission-origin-name {
   font-size: var(--font-md);
   font-weight: 600;

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -1121,6 +1121,7 @@ interface PermissionRecord {
   decision: string;
   createdAt: string;
   lastAccessedAt: string;
+  faviconUrl?: string | null;
 }
 
 let permissionsSearchTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -1207,8 +1207,15 @@ function renderPermissions(permissions: PermissionRecord[]) {
     // Header
     const header = document.createElement('div');
     header.className = 'permission-origin-header';
+    const favicon = perms[0].faviconUrl;
+    const faviconHtml = favicon
+      ? `<img class="permission-origin-favicon" src="${escapeHtml(favicon)}" alt="" onerror="this.outerHTML='<i data-lucide=\\'globe\\' class=\\'permission-origin-favicon\\' width=\\'16\\' height=\\'16\\'></i>'">`
+      : `<i data-lucide="globe" class="permission-origin-favicon" width="16" height="16"></i>`;
     header.innerHTML = `
-      <span class="permission-origin-name">${escapeHtml(origin)}</span>
+      <span class="permission-origin-title">
+        ${faviconHtml}
+        <span class="permission-origin-name">${escapeHtml(origin)}</span>
+      </span>
       <span class="permission-origin-actions">
         <button class="btn btn-sm btn-secondary permission-remove-all-btn"><i data-lucide="trash-2" width="12" height="12"></i> Remove All</button>
       </span>


### PR DESCRIPTION
## Summary
This PR enhances the permission manager UI in browser settings by displaying website favicons alongside origin names, improving visual recognition of sites with stored permissions.

## Key Changes
- **Database Query Enhancement**: Modified `getAllPersistentPermissions()` to fetch favicon URLs from browsing history, matching them to permission origins with a fallback to a globe icon
- **Data Model Update**: Added optional `faviconUrl` field to the `PermissionRecord` interface
- **UI Improvements**: 
  - Created new `.permission-origin-title` flex container to hold favicon and origin name together
  - Added `.permission-origin-favicon` styles for consistent 16x16px favicon display with rounded corners
  - Implemented favicon rendering with graceful fallback to globe icon if image fails to load
  - Wrapped origin name in the new title container for better layout organization

## Implementation Details
- Favicons are retrieved from the `browsingHistory` table, selecting the most recent non-null favicon for each origin
- The SQL query uses a correlated subquery to match history entries by exact URL or URL prefix
- Frontend includes error handling via `onerror` attribute to display a globe icon if favicon image fails to load
- HTML escaping is applied to favicon URLs to prevent XSS vulnerabilities

https://claude.ai/code/session_01Gj5BPC3AKXm3LDsENeJomQ