### PR TITLE
Add blog post: The Indie Browser Renaissance

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -10,6 +10,14 @@ Thoughts on privacy, browsers, and the open web.
 ---
 
 <div class="blog-post-item">
+  <a href="/blog/the-indie-browser-renaissance">
+    <h2>The Indie Browser Renaissance: Meet the Projects Rebuilding the Web on Their Own Terms</h2>
+  </a>
+  <div class="post-meta">By Nav0 Team &middot; April 22, 2026 &middot; 10 min read &middot; Open Web</div>
+  <p class="post-excerpt">A celebratory tour of today's indie browser scene — Min, Helium, Ladybird, Zen, Orion, Qutebrowser, SigmaOS, Floorp, LibreWolf, Nav0, and more — and why a small, scrappy wave of projects matters in a web dominated by four vendors.</p>
+</div>
+
+<div class="blog-post-item">
   <a href="/blog/nav0-vs-opera">
     <h2>Nav0 vs Opera: From Innovation to Monetization</h2>
   </a>

--- a/docs/blog/the-indie-browser-renaissance.md
+++ b/docs/blog/the-indie-browser-renaissance.md
@@ -1,0 +1,156 @@
+---
+title: "The Indie Browser Renaissance: Meet the Projects Rebuilding the Web on Their Own Terms"
+description: "A celebratory survey of today's indie browsers — Min, Helium, Ladybird, Zen, Orion, Qutebrowser, SigmaOS, Floorp, LibreWolf, Beaker, and Nav0 — and why a scrappy wave of small projects matters in a web dominated by four vendors."
+date: 2026-04-22
+author: Nav0 Team
+tags: [indie-browsers, open-web, browsers, privacy]
+head:
+  - - meta
+    - property: og:type
+      content: article
+  - - meta
+    - property: article:published_time
+      content: "2026-04-22"
+  - - meta
+    - property: article:author
+      content: Nav0 Team
+  - - meta
+    - property: article:tag
+      content: indie-browsers
+  - - meta
+    - property: article:tag
+      content: open-web
+  - - meta
+    - property: article:tag
+      content: browsers
+  - - meta
+    - property: article:tag
+      content: privacy
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "The Indie Browser Renaissance: Meet the Projects Rebuilding the Web on Their Own Terms",
+        "description": "A celebratory survey of today's indie browsers — Min, Helium, Ladybird, Zen, Orion, Qutebrowser, SigmaOS, Floorp, LibreWolf, Beaker, and Nav0 — and why a scrappy wave of small projects matters in a web dominated by four vendors.",
+        "datePublished": "2026-04-22",
+        "author": { "@type": "Organization", "name": "Nav0" },
+        "publisher": { "@type": "Organization", "name": "Nav0", "url": "https://nav0.org", "logo": { "@type": "ImageObject", "url": "https://nav0.org/logo.svg" } },
+        "mainEntityOfPage": "https://nav0.org/blog/the-indie-browser-renaissance",
+        "keywords": ["indie browsers", "independent browsers", "alternative browsers", "Min browser", "Helium browser", "Ladybird browser", "Zen browser", "Orion browser", "Qutebrowser", "SigmaOS", "Beaker browser", "Floorp browser", "LibreWolf", "Nav0 browser", "Chromium monoculture", "open web", "browser engine diversity", "minimal browser", "privacy browser", "browser without big tech"]
+      }
+---
+
+# The Indie Browser Renaissance: Meet the Projects Rebuilding the Web on Their Own Terms
+
+<p style="color: var(--vp-c-text-2); font-size: 0.9rem;">By Nav0 Team &middot; April 22, 2026 &middot; 10 min read</p>
+
+For most of the last decade, the browser felt like a solved problem. Four companies — Google, Apple, Microsoft, and Mozilla (itself largely Google-funded) — rendered the web for nearly everyone. Two rendering engines did most of the work. New browsers showed up, but they were almost always Chromium with a different paint job.
+
+Something else has been happening lately. A wave of small, independent browser projects — built by solo developers, volunteer teams, and tiny startups — has quietly become one of the most interesting corners of software. They don't all agree on what a browser should be. That's the point. This post is a tour of the scene, and an argument for why it matters.
+
+## Why Indie Browsers Matter Now
+
+Browser engineering used to be an industry. Now it's also a craft again. That shift matters for three reasons:
+
+**Resisting monoculture.** When roughly 80% of the web runs through Chromium, Google's choices become everyone's defaults. Every indie browser that picks a different engine, or a different UI, or a different data model pushes back against that gravity.
+
+**Serving audiences big vendors won't.** Keyboard-driven power users. People who want Firefox without the telemetry. Mac users who want real extensions on WebKit. Minimalists who want nothing but a tab and an address bar. Big browsers optimize for the average user; indie browsers can optimize for you.
+
+**Keeping the browser a user-agent.** The original HTTP specs called browsers "user agents" because they act on the user's behalf. A lot of modern browsers have drifted into acting on the vendor's behalf instead — [feeding ads](/blog/the-enshittification-of-chrome), [pushing accounts](/blog/why-your-browser-wants-you-to-sign-in), [forcing AI](/blog/stop-forcing-ai-into-browsers). The indie scene is, in large part, a return to the original idea.
+
+## Meet the Indie Browsers
+
+No ranking. No winners. Just a tour, grouped by philosophy.
+
+### The Minimalists
+
+Browsers that treat simplicity as a feature, not an aesthetic.
+
+**[Min](https://minbrowser.org/)** — A JavaScript and Electron browser by Palmer Browser Ltd., MIT-licensed. Min treats search as the central interaction: instead of an address bar plus tabs plus a start page plus bookmarks, it collapses much of that into one input. Built-in ad and tracker blocking, a focus mode, and reading tools. Best for people who want a browser that gets out of the way.
+
+**Nav0** — That's us. A minimal, privacy-focused Electron browser built on the principle: "Browse. Nothing more." Zero telemetry, zero tracking, zero accounts. Ad blocking on by default, DuckDuckGo as the default search, and a deliberately small surface area. Open source, MIT-licensed. Best for people who want Chrome-like familiarity without the data pipeline.
+
+### Built From Scratch
+
+**[Ladybird](https://ladybird.org/)** — The most ambitious project on this list. Ladybird is a brand-new browser engine, not a fork of Blink, Gecko, or WebKit. Originally part of the SerenityOS project, it's now stewarded by a non-profit backed by a small team of full-time engineers. The goal is a standards-compliant, independent web engine with no corporate owner. It's not production-ready yet, and the team says so openly — but if it ships, it will be the first genuinely new browser engine in more than a decade. Best for people who want to back the long game of engine diversity.
+
+### Privacy-Forward Chromium
+
+**[Helium](https://helium.computer/)** — A newer privacy-focused Chromium fork from Imputnet, with a clean UI and hardened defaults. The bet here is simple: Chromium has excellent site compatibility, so keep the engine and rip out the telemetry, the account push, and the Google defaults. Best for people who want Chrome's compatibility without Chrome's surveillance posture.
+
+### Firefox, Reimagined
+
+Three projects that take Firefox in three very different directions.
+
+**[Zen](https://zen-browser.app/)** — A Firefox-based browser built around workspaces, split views, and an ethos of "calm browsing." Zen has become one of the most talked-about indie projects of the last year because of its UI polish. Open source, community-driven. Best for people who liked Arc's ideas but want something independent.
+
+**[Floorp](https://floorp.app/)** — A Japanese open-source Firefox fork with heavy customization, multi-row tabs, vertical tabs, and a deep preferences panel. Floorp keeps Firefox's extension ecosystem fully intact. Best for power users who want Firefox turned up to eleven.
+
+**[LibreWolf](https://librewolf.net/)** — Firefox with privacy-hardened defaults: telemetry stripped out, DuckDuckGo as the default search, uBlock Origin preinstalled, anti-fingerprinting enabled. Minimal divergence from upstream Firefox beyond the defaults, which makes it easy to audit and easy to trust. Best for people who want Firefox without the Mozilla-branded rough edges.
+
+### Mac-Native Rethinks
+
+**[Orion](https://kagi.com/orion)** — A WebKit-based browser from Kagi for macOS, iPadOS, and iOS. Its signature feature is native support for both Chrome and Firefox extensions on top of WebKit, something Safari has never offered. Orion is free to use but is a commercial project funded by Kagi search. Best for Mac users who want Safari's efficiency with real extension support.
+
+**[SigmaOS](https://sigmaos.com/)** — A Mac-native browser built around "workspaces" rather than tabs. Closed-source and freemium, but a genuinely novel take on how a browser could organize a workday. Best for knowledge workers who juggle many projects and want the browser itself to model that structure.
+
+### Keyboard-First
+
+**[Qutebrowser](https://qutebrowser.org/)** — A keyboard-driven browser inspired by Vim, built on QtWebEngine and written in Python. No tab bar, no menu bar by default — everything is a command. GPLv3, cross-platform, and ferociously loved by the people who use it. Best for Vim users and terminal natives who want the browser to feel like the rest of their tooling.
+
+### Experimental & Peer-to-Peer
+
+**[Beaker](https://beakerbrowser.com/)** — It's only fair to acknowledge that Beaker's active development has wound down, but it deserves a place on any honest tour of the indie scene. Beaker was a Chromium-based browser with first-class support for the DAT protocol, letting users host websites peer-to-peer from their own machines. It was a real attempt to make the browser a publishing tool, not just a reading tool. The code and ideas still ship elsewhere, and they're still worth knowing about.
+
+## What They Share
+
+Walk through the list and a pattern emerges.
+
+None of these projects is owned by an ad network. None of them exists to drive traffic to a search engine contract or an app store or a cloud subscription. Their business models — where they have one — are donations, paid tiers, search revenue that *flows to the user's chosen engine*, or simply "the developer felt like making this."
+
+Most of them are open source. Most of them are honest about their tradeoffs. Most of them will tell you, in their own docs, what they deliberately don't do. That kind of clarity is in short supply in the big-vendor browser market, where feature lists mostly grow and privacy policies mostly get longer.
+
+And almost all of them are small enough that the person writing the code is also answering the GitHub issues. That changes the feel of the software in ways that are hard to measure but impossible to miss once you've used it.
+
+## Where They Diverge (Honestly)
+
+A celebratory post would be dishonest without naming the tradeoffs.
+
+**Engine diversity is still mostly a promise.** Most of this list is Chromium or Firefox under the hood. Ladybird is the only project trying to build a third option from scratch, and it's years away from general use. Orion and Qutebrowser ride WebKit and QtWebEngine respectively, which are real alternatives to Blink but still controlled upstream by Apple and Qt.
+
+**Site compatibility varies.** Chromium-based indie browsers inherit Chrome's excellent compatibility. Firefox-based ones inherit Firefox's (very good). Ladybird, by virtue of being new, will fail on sites Chrome handles fine — that's the price of genuine independence.
+
+**Extension support is uneven.** Firefox forks keep the Firefox add-on ecosystem. Orion supports Chrome and Firefox extensions. Chromium forks generally support the Chrome Web Store. Minimalists like Min and Nav0 intentionally skip extensions entirely. Qutebrowser has its own model. If you depend on a specific extension, check before you switch.
+
+**Maturity and release cadence vary wildly.** LibreWolf and Floorp are years old and release on tight schedules. Ladybird is pre-alpha. Helium is young. Beaker is archived. Use the project's own release notes as the ground truth.
+
+**Platform coverage varies.** SigmaOS and Orion are Mac-first. Qutebrowser runs everywhere there's Qt. Zen, LibreWolf, and Floorp cover the Firefox platform matrix. Nav0 runs on macOS, Linux, and Windows via Electron. Check the download page.
+
+No indie browser will beat Chrome on every site on every platform on day one. That's not the bet. The bet is that you get something Chrome can't offer: a browser that isn't trying to sell you anything.
+
+## How to Pick One
+
+Start from your priority, not from a feature checklist.
+
+- **Minimalism above all** → Min or Nav0
+- **Aesthetics and workspace-style tabs** → Zen or SigmaOS
+- **Real extensions on a Mac** → Orion
+- **Keyboard-driven, Vim-style** → Qutebrowser
+- **Firefox, but hardened** → LibreWolf
+- **Firefox, but maxed out** → Floorp
+- **Chrome compatibility without the surveillance** → Helium
+- **A long-term bet on engine diversity** → Ladybird (and be patient)
+
+You don't have to pick one forever. One of the underrated pleasures of the indie scene is that switching is cheap. Keep two. Use a minimalist for reading and a power-user browser for work. Try a Firefox fork for a month. The whole point of the movement is that the browser is, once again, a choice.
+
+## Nav0's Place in This
+
+We built Nav0 because we wanted a browser that just browses — no AI, no VPN upsell, no news feed, no crypto wallet, no sync account, no telemetry. It turns out a lot of other small teams wanted something similar, each in their own direction. We're genuinely happy about that. A healthy indie browser scene is better for everyone on this list, including us, and — far more importantly — better for the web.
+
+If you're here because you've been looking for an alternative to the big four, welcome. Try Nav0. Try the others. The best outcome isn't that you pick us. The best outcome is that you stop treating the browser as something you inherit, and start treating it as something you choose.
+
+---
+
+*Nav0 is a minimal, privacy-focused browser that collects zero data. It's open source, free, and built on the belief that your browser should do one thing well: let you browse the web. [Get started](/guide/getting-started).*


### PR DESCRIPTION
A celebratory survey of today's indie browser ecosystem — Min, Helium,
Ladybird, Zen, Orion, Qutebrowser, SigmaOS, Floorp, LibreWolf, Beaker,
and Nav0 — framing Nav0 as part of a broader movement rather than in
opposition to Big Tech browsers. Updates docs/blog/index.md with the
new entry at the top of the post list.

https://claude.ai/code/session_01X2jix7dkmcVs4gH6v64qm6