### PR TITLE
Properly destroy inactive tabs' WebContents on window close

### DIFF
--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -143,10 +143,11 @@ export abstract class AppWindowManager {
       });
       browserWindow.on('close', () => {
         AppWindowManager.recordWindowTabs(window);
-        // Clear pending timers on all tabs to prevent callbacks after window removal
-        for (const tab of window.getTabs()) {
-          tab.clearPendingTimers();
-        }
+        // Tear down every tab's WebContentsView before the BrowserWindow is
+        // destroyed. Inactive tabs' views are orphaned (not children of
+        // contentView) and would otherwise keep running — playing audio,
+        // holding WebSockets open, etc. — long after the window is gone.
+        window.destroyAllTabs();
       });
       browserWindow.on('closed', () => {
         AppWindowManager.windows.delete(window.id);

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -185,6 +185,42 @@ export class AppWindow {
     this.browserWindowInstance.on('resize', this.handleResizing.bind(this));
   }
 
+  /**
+   * Tear down every tab's WebContentsView. Inactive tabs are not children of
+   * the BrowserWindow's contentView (activateTab removes the previous view on
+   * tab switch), so their WebContents wouldn't otherwise be destroyed when the
+   * window closes — they'd keep running, holding open WebSockets and playing
+   * audio (e.g. WhatsApp Web message pings). Call this from every window-close
+   * path before the BrowserWindow is destroyed.
+   */
+  public destroyAllTabs(): void {
+    for (const [id, tab] of this.tabs) {
+      try {
+        tab.finalizePageTime();
+      } catch {
+        /* best-effort */
+      }
+      tab.clearPendingTimers();
+      PermissionManager.clearSessionPermissionsForTab(id);
+      const view = tab.getWebContentsViewInstance();
+      if (!view) continue;
+      try {
+        NotificationManager.clearNotificationsForWebContents(view.webContents.id);
+      } catch {
+        /* best-effort */
+      }
+      try {
+        view.webContents.removeAllListeners();
+        view.removeAllListeners();
+        if (!view.webContents.isDestroyed()) {
+          view.webContents.close();
+        }
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
   public closeWindow(clearSession: boolean) {
     for (const tab of this.tabs.values()) {
       tab.clearPendingTimers();


### PR DESCRIPTION
## Summary
This PR fixes a resource leak where inactive browser tabs would continue running after their window was closed, keeping WebSockets open and playing audio. The fix ensures all tabs' WebContentsView instances are properly torn down before the BrowserWindow is destroyed.

## Key Changes
- Added `destroyAllTabs()` method to `AppWindow` that:
  - Iterates through all tabs and finalizes their page time
  - Clears pending timers and session permissions
  - Removes all event listeners from WebContents and WebContentsView
  - Properly closes WebContents if not already destroyed
  - Clears associated notifications
  - Uses try-catch blocks for best-effort cleanup to prevent one tab's failure from blocking others

- Updated `AppWindowManager`'s window 'close' event handler to call `destroyAllTabs()` instead of only clearing pending timers
  - This ensures inactive tabs (which are not children of the BrowserWindow's contentView) are properly cleaned up

## Implementation Details
The issue occurred because inactive tabs are removed from the BrowserWindow's contentView when switching tabs, making them orphaned. Without explicit cleanup, their WebContents would persist after window closure, continuing to consume resources and maintain connections. The new `destroyAllTabs()` method handles cleanup for all tabs regardless of their active state, with defensive error handling to ensure partial failures don't prevent complete cleanup.

https://claude.ai/code/session_01Cawrk2E15vG4Y9cdNYS9Vh