### PR TITLE
Remove filter buttons from command-k panel

### DIFF
--- a/src/renderer/overlay/panels/command-k/command-k.css
+++ b/src/renderer/overlay/panels/command-k/command-k.css
@@ -71,53 +71,6 @@
   margin: 0 2px;
 }
 
-/* Action buttons */
-#overlay-command-k .action-buttons {
-  display: flex;
-  gap: var(--spacing-sm);
-  padding: 12px var(--spacing-md);
-  border-bottom: 1px solid #eaeaea;
-  overflow-x: auto;
-  scrollbar-width: none; /* Firefox */
-}
-
-#overlay-command-k .action-buttons::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
-}
-
-#overlay-command-k .action-btn {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  background-color: var(--bg-color);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  padding: 10px 16px 10px 16px;
-  font-size: var(--font-sm);
-  color: var(--text-color);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.2s;
-}
-
-#overlay-command-k .action-btn:hover {
-  border-color: var(--border-color-dark);
-}
-
-#overlay-command-k .action-btn i {
-  color: var(--primary-color);
-}
-
-#overlay-command-k .action-btn.primary {
-  background-color: var(--primary-light);
-  border-color: #d4d4d4;
-  color: var(--primary-color);
-}
-
-#overlay-command-k .action-btn.primary:hover {
-  background-color: #e5e5e5;
-}
-
 /* Results section */
 #overlay-command-k .results-container {
   flex: 1;

--- a/src/renderer/overlay/panels/command-k/command-k.ts
+++ b/src/renderer/overlay/panels/command-k/command-k.ts
@@ -10,7 +10,6 @@ type ResultItem = {
   tabId?: string;
 };
 
-let activeFilter: 'all' | 'tabs' | 'bookmarks' | 'history' | 'downloads' = 'all';
 let activeIndex = -1;
 let currentResults: ResultItem[] = [];
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -20,7 +19,6 @@ let searchInput: HTMLInputElement;
 let resultsContainer: HTMLElement;
 let emptyState: HTMLElement;
 let loadingIndicator: HTMLElement;
-let actionButtons: NodeListOf<HTMLButtonElement>;
 
 const COMMAND_K_HTML = `
   <div class="command-container">
@@ -34,30 +32,6 @@ const COMMAND_K_HTML = `
         <span class="key">\u2193</span>
         <span class="key">Enter</span>
       </div>
-    </div>
-
-    <!-- Action buttons -->
-    <div class="action-buttons">
-      <button class="action-btn primary" data-filter="all">
-        <i data-lucide="layers" width="16" height="16"></i>
-        All
-      </button>
-      <button class="action-btn" data-filter="bookmarks">
-        <i data-lucide="bookmark" width="16" height="16"></i>
-        Bookmarks
-      </button>
-      <button class="action-btn" data-filter="history">
-        <i data-lucide="history" width="16" height="16"></i>
-        History
-      </button>
-      <button class="action-btn" data-filter="tabs">
-        <i data-lucide="app-window" width="16" height="16"></i>
-        Tabs
-      </button>
-      <button class="action-btn" data-filter="downloads">
-        <i data-lucide="download" width="16" height="16"></i>
-        Downloads
-      </button>
     </div>
 
     <!-- Results section -->
@@ -283,33 +257,11 @@ const performSearch = async (query: string) => {
     const results: ResultItem[] = [];
     const lowerQuery = query.toLowerCase();
 
-    // Fetch open tabs (filtered client-side)
-    const fetchTabs =
-      activeFilter === 'all' || activeFilter === 'tabs'
-        ? window.BrowserAPI.fetchOpenTabs(window.BrowserAPI.appWindowId)
-        : Promise.resolve([]);
-
-    // Fetch data based on active filter
-    const fetchBookmarks =
-      activeFilter === 'all' || activeFilter === 'bookmarks'
-        ? window.BrowserAPI.fetchBookmarks(window.BrowserAPI.appWindowId, query, 5, 0)
-        : Promise.resolve([]);
-
-    const fetchHistory =
-      activeFilter === 'all' || activeFilter === 'history'
-        ? window.BrowserAPI.fetchBrowsingHistory(window.BrowserAPI.appWindowId, query, 5, 0)
-        : Promise.resolve([]);
-
-    const fetchDownloads =
-      activeFilter === 'all' || activeFilter === 'downloads'
-        ? window.BrowserAPI.fetchDownloads(window.BrowserAPI.appWindowId, query, 5, 0)
-        : Promise.resolve([]);
-
     const [openTabs, bookmarks, history, downloads] = await Promise.all([
-      fetchTabs,
-      fetchBookmarks,
-      fetchHistory,
-      fetchDownloads,
+      window.BrowserAPI.fetchOpenTabs(window.BrowserAPI.appWindowId),
+      window.BrowserAPI.fetchBookmarks(window.BrowserAPI.appWindowId, query, 5, 0),
+      window.BrowserAPI.fetchBrowsingHistory(window.BrowserAPI.appWindowId, query, 5, 0),
+      window.BrowserAPI.fetchDownloads(window.BrowserAPI.appWindowId, query, 5, 0),
     ]);
 
     // Filter tabs client-side by title and URL
@@ -484,18 +436,6 @@ export function init(container: HTMLElement): void {
   resultsContainer = container.querySelector('#cmdk-results-container') as HTMLElement;
   emptyState = container.querySelector('#cmdk-empty-state') as HTMLElement;
   loadingIndicator = container.querySelector('#cmdk-loading-indicator') as HTMLElement;
-  actionButtons = container.querySelectorAll<HTMLButtonElement>('.action-btn');
-
-  // Filter button handling
-  actionButtons.forEach((button) => {
-    button.addEventListener('click', () => {
-      actionButtons.forEach((b) => b.classList.remove('primary'));
-      button.classList.add('primary');
-      activeFilter = (button.dataset.filter as typeof activeFilter) || 'all';
-      const query = searchInput.value;
-      performSearch(query);
-    });
-  });
 
   // Listen at document level so Escape/Tab/arrows work regardless of focus
   document.addEventListener('keydown', handleKeydown);
@@ -509,15 +449,9 @@ export function init(container: HTMLElement): void {
 
 export function show(_data?: any): void {
   // Reset state
-  activeFilter = 'all';
   activeIndex = -1;
   currentResults = [];
   if (debounceTimer) clearTimeout(debounceTimer);
-
-  // Reset filter buttons
-  actionButtons.forEach((b) => b.classList.remove('primary'));
-  const allBtn = containerEl.querySelector('.action-btn[data-filter="all"]') as HTMLButtonElement;
-  if (allBtn) allBtn.classList.add('primary');
 
   // Clear and focus search input
   if (searchInput) {


### PR DESCRIPTION
## Summary
This PR removes the filter button UI and associated filtering logic from the command-k panel. The panel now always fetches and displays results from all sources (tabs, bookmarks, history, downloads) without the ability to filter by category.

## Key Changes
- **Removed UI elements**: Deleted the action buttons section from the HTML template that allowed users to filter by "All", "Bookmarks", "History", "Tabs", and "Downloads"
- **Simplified search logic**: Removed conditional fetching based on `activeFilter` state; all data sources are now always fetched regardless of user input
- **Removed state management**: Deleted the `activeFilter` variable and `actionButtons` DOM reference that tracked the selected filter
- **Removed event handlers**: Eliminated click event listeners on filter buttons that updated the active filter and triggered new searches
- **Removed CSS styling**: Deleted all styles related to `.action-buttons` and `.action-btn` classes
- **Simplified initialization**: Removed filter button setup logic from the `init()` function
- **Simplified reset logic**: Removed filter state reset from the `show()` function

## Implementation Details
The search now unconditionally calls all four data-fetching APIs:
- `fetchOpenTabs()`
- `fetchBookmarks()`
- `fetchBrowsingHistory()`
- `fetchDownloads()`

Results from all sources are combined and displayed together, with client-side filtering still applied for tabs (by title and URL).

https://claude.ai/code/session_01H1J1YMDsbDBfJ7fR8h2hUv