### PR TITLE
Release v0.2.5: New tab improvements and Electron 41 upgrade

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,10 +10,18 @@ What's new in every release of Nav0 Browser.
 ---
 
 <div class="release-list-item">
+  <a href="/releases/v0.2.5">
+    <h2>v0.2.5</h2>
+  </a>
+  <div class="release-meta">May 5, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Time-based greetings and a pastel-gradient new-tab page, fixed WebContents cleanup on window close, a streamlined Command-K, the new compass logo across the app, and an Electron 41 upgrade.</p>
+</div>
+
+<div class="release-list-item">
   <a href="/releases/v0.2.4">
     <h2>v0.2.4</h2>
   </a>
-  <div class="release-meta">April 23, 2026 <span class="release-badge latest">Latest</span></div>
+  <div class="release-meta">April 23, 2026</div>
   <p class="release-excerpt">Settings page redesign, favicons next to origins in Site Permissions, and a new linting/formatting/pre-commit-hook tooling stack.</p>
 </div>
 

--- a/docs/releases/v0.2.4.md
+++ b/docs/releases/v0.2.4.md
@@ -1,12 +1,9 @@
 ---
 title: 'v0.2.4'
 date: 2026-04-23
-badge: Latest
 ---
 
 # v0.2.4
-
-<span class="release-badge latest">Latest</span>
 
 <div class="release-date-meta">April 23, 2026</div>
 

--- a/docs/releases/v0.2.5.md
+++ b/docs/releases/v0.2.5.md
@@ -1,0 +1,37 @@
+---
+title: 'v0.2.5'
+date: 2026-05-05
+badge: Latest
+---
+
+# v0.2.5
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">May 5, 2026</div>
+
+## New Tab
+
+- **Time-Based Greetings** — the new-tab page now greets you with messages tailored to the time of day instead of a static "Hello"
+- **More Greeting Variations** — expanded to ten greeting variations per time bucket for more variety across visits
+- **Pastel Gradient Background** — new-tab now displays a randomised, subtle pastel gradient background
+
+## Browser
+
+- **WebContents Cleanup on Window Close** — inactive tab `WebContentsView`s are now properly destroyed when a window closes, fixing lingering background activity (e.g. WhatsApp keeping notifications alive after the window was closed)
+
+## Command Palette
+
+- **Simplified Layout** — removed the filter buttons section from the Command-K overlay for a cleaner palette
+
+## Branding
+
+- **New Compass Logo** — rolled out the new compass logo across the app (window icon, renderer assets, internal references)
+
+## Dependencies
+
+- **Electron 41** — upgraded Electron from 35.2.1 to 41.0.0, bringing Chromium 146, Node 24.14.0, and V8 14.6, along with related tooling updates
+
+## Cleanup
+
+- **Removed Logo Generator Script** — removed the one-shot `scripts/generate-logo-assets.js` after the logo rollout was complete

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Nav0",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Nav0",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nav0",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main/index.js",


### PR DESCRIPTION
## Summary
This PR releases v0.2.5 of Nav0 Browser, featuring enhancements to the new-tab page, browser improvements, and a major Electron upgrade.

## Key Changes
- **New-tab page enhancements**: Added time-based greetings with ten variations per time bucket and a randomized pastel gradient background
- **Browser improvements**: Fixed WebContents cleanup on window close to prevent background activity from inactive tabs
- **Command Palette**: Simplified layout by removing the filter buttons section
- **Branding**: Rolled out the new compass logo across the app
- **Dependencies**: Upgraded Electron from 35.2.1 to 41.0.0 (Chromium 146, Node 24.14.0, V8 14.6)
- **Cleanup**: Removed the one-shot logo generator script after rollout completion
- **Version bump**: Updated package.json from v0.2.4 to v0.2.5
- **Release documentation**: Added v0.2.5 release notes and updated the releases index to mark v0.2.5 as latest

## Notable Details
The "Latest" badge has been moved from v0.2.4 to v0.2.5 in the release documentation, reflecting the new version as the current stable release.

https://claude.ai/code/session_016M9aUjQ5B3EoY5Q7QZj4Ze