### PR TITLE
Update main entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.5",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
-  "main": ".webpack/main/index.js",
+  "main": ".webpack/main",
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",


### PR DESCRIPTION
## Summary
Updated the `main` field in package.json to reference the webpack output directory instead of a specific index.js file.

## Changes
- Changed `main` entry point from `.webpack/main/index.js` to `.webpack/main`
  - This allows Node.js to automatically resolve the entry point (typically index.js) within the directory
  - Simplifies the configuration and makes it more maintainable if the entry file structure changes

## Details
This is a minor configuration adjustment that leverages Node.js's default module resolution behavior. When a directory is specified as the main entry point, Node.js will automatically look for an `index.js` file within that directory, eliminating the need to explicitly reference it in the path.

https://claude.ai/code/session_01J68BqkW1ENuynxJbEi9kJm