### PR TITLE
Update user agent strings and improve Google sign-in detection

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -141,7 +141,11 @@ export abstract class SettingsEnforcer {
         // chosen preset.
         let isGoogleSignIn = false;
         try {
-          isGoogleSignIn = new URL(details.url).hostname === 'accounts.google.com';
+          const host = new URL(details.url).hostname;
+          isGoogleSignIn =
+            host === 'accounts.google.com' ||
+            host.endsWith('.accounts.google.com') ||
+            host === 'accounts.youtube.com';
         } catch {
           /* ignore */
         }
@@ -162,24 +166,19 @@ export abstract class SettingsEnforcer {
     }
   }
 
-  // Firefox UA generator (adapted from Min browser's UASwitcher.js).
-  // Estimates the current Firefox major version: v91 was released on
-  // 2021-08-10, and new major versions ship roughly every 4.1 weeks.
+  // Pinned to a recently-released Firefox stable. Bump on each Electron
+  // upgrade. Extrapolating a Firefox major from a 2021 baseline drifts ahead
+  // of any released build, which trips Google's anomaly detection on the
+  // sign-in path.
   private static getFirefoxUA(): string {
-    const rootUAs = {
-      mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
-      windows:
-        'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
-      linux:
-        'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:FXVERSION.0) Gecko/20100101 Firefox/FXVERSION.0',
-    };
-    let rootUA: string;
-    if (process.platform === 'win32') rootUA = rootUAs.windows;
-    else if (process.platform === 'darwin') rootUA = rootUAs.mac;
-    else rootUA = rootUAs.linux;
-    const fxVersion =
-      91 + Math.floor((Date.now() - 1628553600000) / (4.1 * 7 * 24 * 60 * 60 * 1000));
-    return rootUA.replace(/FXVERSION/g, String(fxVersion));
+    const FX_VERSION = 138;
+    if (process.platform === 'win32') {
+      return `Mozilla/5.0 (Windows NT 10.0; WOW64; rv:${FX_VERSION}.0) Gecko/20100101 Firefox/${FX_VERSION}.0`;
+    }
+    if (process.platform === 'darwin') {
+      return `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:${FX_VERSION}.0) Gecko/20100101 Firefox/${FX_VERSION}.0`;
+    }
+    return `Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:${FX_VERSION}.0) Gecko/20100101 Firefox/${FX_VERSION}.0`;
   }
 
   // ---- Response Header Policy (Cookie Jar Enforcement) ----

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -182,17 +182,17 @@ export const USER_AGENT_PRESETS: Record<string, { label: string; value: string }
   'chrome-windows': {
     label: 'Chrome on Windows',
     value:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
   },
   'chrome-mac': {
     label: 'Chrome on macOS',
     value:
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
   },
   'chrome-linux': {
     label: 'Chrome on Linux',
     value:
-      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
   },
   'safari-mac': {
     label: 'Safari on macOS',
@@ -214,7 +214,7 @@ export const USER_AGENT_PRESETS: Record<string, { label: string; value: string }
   'edge-windows': {
     label: 'Edge on Windows',
     value:
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36 Edg/146.0.0.0',
   },
   custom: {
     label: 'Custom',


### PR DESCRIPTION
## Summary
This PR updates user agent strings to more recent browser versions and improves Google sign-in detection to handle additional Google-owned domains.

## Key Changes

- **Google Sign-In Detection**: Enhanced the sign-in detection logic to recognize additional Google domains:
  - Added support for subdomains of `accounts.google.com` (e.g., `subdomain.accounts.google.com`)
  - Added support for `accounts.youtube.com`

- **Firefox User Agent**: Replaced dynamic version calculation with a pinned Firefox 138 user agent string
  - Removed the version estimation logic that extrapolated from a 2021 baseline
  - Pinned to Firefox 138 to avoid triggering Google's anomaly detection on sign-in paths
  - Simplified implementation with direct string templates for each platform

- **Chrome/Edge User Agent Updates**: Updated Chrome and Edge user agent strings from version 136 to 146
  - Updated Chrome on Windows, macOS, and Linux
  - Updated Edge on Windows

## Implementation Details

The Firefox UA change addresses a specific issue where the extrapolated version would drift ahead of actual released builds, causing Google's security checks to flag the requests as anomalous. By pinning to a recently-released stable version, the sign-in flow is more reliable. The version should be bumped on each Electron upgrade to maintain compatibility.

The Google sign-in detection improvements ensure that authentication flows work correctly across Google's various domain configurations, including YouTube's authentication endpoints.

https://claude.ai/code/session_01KQoRbgNKWh3pKKAzWW42Q5