### PR TITLE
Soften new tab background gradients with muted color palette

### DIFF
--- a/src/renderer/pages/new-tab/index.ts
+++ b/src/renderer/pages/new-tab/index.ts
@@ -120,16 +120,16 @@ function getTimeBasedGreeting(): string {
 }
 
 const BACKGROUND_GRADIENTS: string[] = [
-  'linear-gradient(135deg, #fde6dc 0%, #fce4ec 50%, #e8eaf6 100%)',
-  'linear-gradient(135deg, #ffe0b2 0%, #fce4ec 50%, #e1bee7 100%)',
-  'linear-gradient(135deg, #e3f2fd 0%, #f3e5f5 100%)',
-  'linear-gradient(135deg, #f1f8e9 0%, #e0f7fa 100%)',
-  'linear-gradient(135deg, #fff8e1 0%, #fce4ec 100%)',
-  'linear-gradient(135deg, #e1f5fe 0%, #ede7f6 100%)',
-  'linear-gradient(135deg, #fce4ec 0%, #fff3e0 100%)',
-  'linear-gradient(135deg, #f3e5f5 0%, #e8eaf6 50%, #e0f7fa 100%)',
-  'linear-gradient(135deg, #fff5f0 0%, #f0f4ff 100%)',
-  'linear-gradient(135deg, #fef6e4 0%, #f4e9f7 100%)',
+  'linear-gradient(135deg, #fbf8f6 0%, #fbf9fa 50%, #f9f9fb 100%)',
+  'linear-gradient(135deg, #fcfaf6 0%, #fbf9fa 50%, #faf8fb 100%)',
+  'linear-gradient(135deg, #f8fafc 0%, #fbf9fc 100%)',
+  'linear-gradient(135deg, #fafbf7 0%, #f8fbfc 100%)',
+  'linear-gradient(135deg, #fcfbf5 0%, #fbf9fa 100%)',
+  'linear-gradient(135deg, #f8fbfd 0%, #faf9fc 100%)',
+  'linear-gradient(135deg, #fbf9fa 0%, #fcfaf6 100%)',
+  'linear-gradient(135deg, #fbf9fc 0%, #f9f9fb 50%, #f8fbfc 100%)',
+  'linear-gradient(135deg, #fcfaf8 0%, #f9fafd 100%)',
+  'linear-gradient(135deg, #fcfbf5 0%, #fbf9fc 100%)',
 ];
 
 function pickRandomBackground(): string {


### PR DESCRIPTION
## Summary
Updated the background gradient color palette for the new tab page to use softer, more muted tones instead of vibrant Material Design colors.

## Changes
- Replaced all 10 background gradients in `BACKGROUND_GRADIENTS` array with softer, neutral color variants
- Shifted from bright, saturated colors (e.g., `#fde6dc`, `#ffe0b2`, `#e3f2fd`) to subtle, desaturated grays and off-whites (e.g., `#fbf8f6`, `#fcfaf6`, `#f8fafc`)
- Maintained the same gradient structure and angle (135deg) for consistency
- Preserved the multi-stop gradient patterns where applicable

## Details
The new color palette uses high-value, low-saturation colors that create a more minimalist and calming aesthetic while maintaining visual variety across the 10 gradient options. This change improves the visual hierarchy by reducing distraction from the main content on the new tab page.

https://claude.ai/code/session_01Y5dykUWJXnUxWPDhiSbZNm