### PR TITLE
Release v0.2.6: packaging fix, Google sign-in, softer gradient

### DIFF
--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -10,10 +10,18 @@ What's new in every release of Nav0 Browser.
 ---
 
 <div class="release-list-item">
+  <a href="/releases/v0.2.6">
+    <h2>v0.2.6</h2>
+  </a>
+  <div class="release-meta">May 6, 2026 <span class="release-badge latest">Latest</span></div>
+  <p class="release-excerpt">Fixed packaging breakage from the Electron 41 upgrade, restored Google sign-in by refreshing Firefox UA cap and Chrome preset, and softened the new-tab gradient background.</p>
+</div>
+
+<div class="release-list-item">
   <a href="/releases/v0.2.5">
     <h2>v0.2.5</h2>
   </a>
-  <div class="release-meta">May 5, 2026 <span class="release-badge latest">Latest</span></div>
+  <div class="release-meta">May 5, 2026</div>
   <p class="release-excerpt">Time-based greetings and a pastel-gradient new-tab page, fixed WebContents cleanup on window close, a streamlined Command-K, the new compass logo across the app, and an Electron 41 upgrade.</p>
 </div>
 

--- a/docs/releases/v0.2.5.md
+++ b/docs/releases/v0.2.5.md
@@ -1,12 +1,9 @@
 ---
 title: 'v0.2.5'
 date: 2026-05-05
-badge: Latest
 ---
 
 # v0.2.5
-
-<span class="release-badge latest">Latest</span>
 
 <div class="release-date-meta">May 5, 2026</div>
 

--- a/docs/releases/v0.2.6.md
+++ b/docs/releases/v0.2.6.md
@@ -1,0 +1,20 @@
+---
+title: 'v0.2.6'
+date: 2026-05-06
+badge: Latest
+---
+
+# v0.2.6
+
+<span class="release-badge latest">Latest</span>
+
+<div class="release-date-meta">May 6, 2026</div>
+
+## Bug Fixes
+
+- **Packaging Regression Fix** — restored `package.json`'s `main` field to `.webpack/main`. The Electron 35 → 41 upgrade in v0.2.5 had changed the source value to `.webpack/main/index.js`, which the Forge Webpack plugin rejects in `packageAfterCopy`, breaking `electron-forge package` / `make`. The existing `packageAfterPrune` hook still rewrites the packaged `package.json` so Electron's ESM main loader can resolve it
+- **Google Sign-in Unblocked** — refreshed Firefox UA cap (pinned to Firefox 138 instead of an extrapolated future version that tripped Google's anomaly detection), widened the Google sign-in host match to `*.accounts.google.com` and `accounts.youtube.com` so redirects through subdomains aren't sent as Chrome, and bumped the Chrome preset to match Electron 41's Chromium 146 so runtime UA alignment can't be bypassed
+
+## New Tab
+
+- **Softer Gradient Background** — replaced the saturated pastel gradient stops introduced in v0.2.5 with near-white equivalents, so the new-tab page reads as essentially white at a glance while retaining each gradient's hue identity on close inspection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Nav0",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Nav0",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nav0",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
Release v0.2.6 addresses a packaging regression from the Electron 41 upgrade, restores Google sign-in functionality, and refines the new-tab page styling.

## Changes
- **Packaging Regression Fix** — Restored `package.json`'s `main` field to `.webpack/main` (reverted from `.webpack/main/index.js`). The Electron 35 → 41 upgrade in v0.2.5 broke `electron-forge package` / `make` because the Forge Webpack plugin rejects the longer path in `packageAfterCopy`. The existing `packageAfterPrune` hook still rewrites the packaged `package.json` for Electron's ESM main loader.

- **Google Sign-in Unblocked** — Refreshed Firefox UA cap (pinned to Firefox 138 instead of an extrapolated future version that triggered Google's anomaly detection), widened the Google sign-in host match to `*.accounts.google.com` and `accounts.youtube.com` to handle subdomain redirects, and bumped the Chrome preset to match Electron 41's Chromium 146 for runtime UA alignment.

- **Softer Gradient Background** — Replaced the saturated pastel gradient stops from v0.2.5 with near-white equivalents, making the new-tab page appear essentially white at a glance while retaining subtle hue identity on close inspection.

- **Release Documentation** — Added v0.2.6 release notes and updated the releases index to mark v0.2.6 as latest.

- **Version Bump** — Updated `package.json` version from 0.2.5 to 0.2.6.

https://claude.ai/code/session_01ETvg1GRqJAyArhfEhFDirJ