### PR TITLE
Restore existing windows on dock icon click instead of always creating new

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,8 +90,19 @@ app.on('before-quit', async () => {
   await SettingsEnforcer.onBeforeQuit();
 });
 
-// Re-create window when dock icon is clicked (macOS)
+// Restore an existing window when the dock icon is clicked (macOS). Only fall
+// back to creating a new window if every window has been closed — matching the
+// platform convention used by Safari, Chrome, and Finder.
 app.on('activate', () => {
+  const existing = AppWindowManager.getActiveWindow() ?? AppWindowManager.getWindows()[0];
+  if (existing) {
+    const bw = existing.getBrowserWindowInstance();
+    if (bw) {
+      if (bw.isMinimized()) bw.restore();
+      bw.focus();
+      return;
+    }
+  }
   AppWindowManager.createWindow(false);
 });
 


### PR DESCRIPTION
## Summary
Modified the `activate` event handler to restore an existing window when the dock icon is clicked on macOS, rather than always creating a new window. This aligns the application's behavior with platform conventions used by Safari, Chrome, and Finder.

## Key Changes
- Updated the `activate` event handler to first attempt to restore an existing window before creating a new one
- Prioritizes the active window, falling back to the first available window if none are currently active
- Restores minimized windows and focuses them when the dock icon is clicked
- Only creates a new window if all windows have been closed

## Implementation Details
- Retrieves the active window via `AppWindowManager.getActiveWindow()`, with a fallback to the first window in the list
- Checks if the window has a valid browser window instance before attempting to restore/focus it
- Restores minimized windows using `bw.restore()` before calling `bw.focus()`
- Maintains backward compatibility by still creating a new window when no windows exist

https://claude.ai/code/session_017irvqDnmB5fzutXLu2w2h2