### PR TITLE
Redesign release notes pages with hero sections and timeline

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -301,8 +301,10 @@ export default defineConfig({
 
     if (pageData.relativePath === 'releases/index.md') {
       pageData.frontmatter.pageClass = 'releases-index-page';
+      pageData.frontmatter.layout = 'page';
     } else if (pageData.relativePath.startsWith('releases/')) {
       pageData.frontmatter.pageClass = 'release-detail-page';
+      pageData.frontmatter.layout = 'page';
     }
 
     // Inject SoftwareApplication schema only on relevant pages

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -299,6 +299,12 @@ export default defineConfig({
       ['meta', { property: 'og:url', content: canonicalUrl }]
     );
 
+    if (pageData.relativePath === 'releases/index.md') {
+      pageData.frontmatter.pageClass = 'releases-index-page';
+    } else if (pageData.relativePath.startsWith('releases/')) {
+      pageData.frontmatter.pageClass = 'release-detail-page';
+    }
+
     // Inject SoftwareApplication schema only on relevant pages
     const softwareAppPages = ['index.md', 'install.md', 'guide/features.md'];
     if (softwareAppPages.includes(pageData.relativePath)) {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,13 +1,30 @@
-<script setup>
+<script setup lang="ts">
 import DefaultTheme from 'vitepress/theme';
+import { useData } from 'vitepress';
+import { computed } from 'vue';
+import ReleaseDetailHero from './components/ReleaseDetailHero.vue';
+import ReleaseDetailSidebar from './components/ReleaseDetailSidebar.vue';
 
 const { Layout } = DefaultTheme;
+const { page } = useData();
+
+const isReleaseDetail = computed(() => {
+  const path = page.value.relativePath || '';
+  return path.startsWith('releases/') && path !== 'releases/index.md';
+});
 </script>
 
 <template>
   <div class="nav0-bg">
     <div class="nav0-bg-pattern"></div>
     <div class="nav0-bg-vignette"></div>
-    <Layout />
+    <Layout>
+      <template v-if="isReleaseDetail" #page-top>
+        <ReleaseDetailHero />
+      </template>
+      <template v-if="isReleaseDetail" #page-bottom>
+        <ReleaseDetailSidebar />
+      </template>
+    </Layout>
   </div>
 </template>

--- a/docs/.vitepress/theme/components/ReleaseDetailHero.vue
+++ b/docs/.vitepress/theme/components/ReleaseDetailHero.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { useData } from 'vitepress';
+import { computed } from 'vue';
+import { data as releases } from '../releases.data';
+
+const { page, frontmatter } = useData();
+
+const current = computed(() => {
+  const url = page.value.relativePath
+    .replace(/\.md$/, '')
+    .replace(/^/, '/')
+    .replace(/^\/+/, '/');
+  // The data loader uses cleanUrls (no .html) — match by URL ending
+  return (
+    releases.all.find((r) => r.url === url || url.endsWith(r.url)) ??
+    releases.all.find((r) => r.version === (frontmatter.value.title as string)) ??
+    null
+  );
+});
+
+const isLatest = computed(() => {
+  if (!current.value || !releases.latest) return false;
+  return current.value.url === releases.latest.url;
+});
+
+const isAlpha = computed(() => current.value?.isAlpha ?? false);
+
+const headline = computed(
+  () => current.value?.headline || `Release ${current.value?.version ?? ''}.`
+);
+
+const tagText = computed(() => {
+  if (!current.value) return '';
+  if (isAlpha.value) return `Alpha · ${current.value.dateLong}`;
+  if (isLatest.value) return `Latest stable · ${current.value.dateLong}`;
+  return `Released ${current.value.dateLong}`;
+});
+
+const version = computed(
+  () => current.value?.version || (frontmatter.value.title as string) || ''
+);
+</script>
+
+<template>
+  <section class="rel-detail-hero" v-if="current">
+    <div class="rel-detail-hero-inner">
+      <nav class="rel-detail-breadcrumb" aria-label="Breadcrumb">
+        <a href="/">Nav0</a>
+        <span class="sep">›</span>
+        <a href="/releases/">Releases</a>
+        <span class="sep">›</span>
+        <span class="current">{{ version }}</span>
+      </nav>
+
+      <div class="rel-detail-tag" :class="{ 'is-alpha': isAlpha }">
+        <span class="rel-detail-pulse" v-if="isLatest" aria-hidden="true"></span>
+        {{ tagText }}
+      </div>
+
+      <h1 class="rel-detail-version">{{ version }}</h1>
+
+      <p class="rel-detail-headline">{{ headline }}</p>
+
+      <div class="rel-detail-cta-row">
+        <a class="rel-detail-cta-primary" href="/install">Download Nav0</a>
+        <a class="rel-detail-cta-secondary" href="#" onclick="window.scrollTo({top:document.querySelector('.vp-doc')?.getBoundingClientRect().top+window.scrollY-80,behavior:'smooth'});return false;">
+          Read all changes
+        </a>
+        <a
+          class="rel-detail-cta-secondary"
+          :href="`https://github.com/nav0-org/nav0-browser/releases/tag/${version}`"
+          target="_blank"
+          rel="noopener"
+        >
+          View on GitHub ›
+        </a>
+      </div>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/components/ReleaseDetailSidebar.vue
+++ b/docs/.vitepress/theme/components/ReleaseDetailSidebar.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { useData } from 'vitepress';
+import { computed } from 'vue';
+
+const { frontmatter } = useData();
+
+const version = computed(() => (frontmatter.value.title as string) || '');
+</script>
+
+<template>
+  <aside class="rel-detail-side">
+    <div class="rel-detail-quick-download">
+      <h5>Quick download</h5>
+      <div class="rel-detail-download-row">
+        <span class="rel-detail-download-name">macOS</span>
+        <a href="/install#macos">.dmg</a>
+      </div>
+      <div class="rel-detail-download-row">
+        <span class="rel-detail-download-name">Linux</span>
+        <a href="/install#linux">.deb</a>
+      </div>
+      <div class="rel-detail-download-row">
+        <span class="rel-detail-download-name">Windows</span>
+        <a href="/install#windows">.exe</a>
+      </div>
+      <div class="rel-detail-download-row">
+        <span class="rel-detail-download-name">Source</span>
+        <a
+          :href="`https://github.com/nav0-org/nav0-browser/archive/refs/tags/${version}.tar.gz`"
+          >.tar.gz</a
+        >
+      </div>
+    </div>
+
+    <div class="rel-detail-side-section">
+      <h5>All releases</h5>
+      <p class="rel-detail-side-link">
+        <a href="/releases/">‹ Back to all releases</a>
+      </p>
+    </div>
+  </aside>
+</template>

--- a/docs/.vitepress/theme/components/ReleasesLatestHero.vue
+++ b/docs/.vitepress/theme/components/ReleasesLatestHero.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { data as releases } from '../releases.data';
+
+const { latest } = releases;
+</script>
+
+<template>
+  <div class="rel-latest-hero" v-if="latest">
+    <div class="rel-latest-hero-inner">
+      <div class="rel-latest-hero-main">
+        <div class="rel-latest-tag">
+          <span class="rel-latest-pulse" aria-hidden="true"></span>
+          Latest · {{ latest.dateLong }}
+        </div>
+        <div class="rel-latest-version">{{ latest.version }}</div>
+        <p class="rel-latest-headline">
+          <slot>The most recent shipped change.</slot>
+        </p>
+        <div class="rel-latest-cta-row">
+          <a class="rel-latest-cta-primary" :href="latest.url">Read full notes</a>
+          <a class="rel-latest-cta-secondary" href="/install">Download Nav0</a>
+        </div>
+      </div>
+      <div class="rel-latest-hero-summary" v-if="$slots.summary">
+        <h4>What's in this one</h4>
+        <slot name="summary" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/components/ReleasesStats.vue
+++ b/docs/.vitepress/theme/components/ReleasesStats.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { data as releases } from '../releases.data';
+
+const { latest, totalCount, cadenceDays } = releases;
+
+const sinceLabel = (() => {
+  if (!releases.all.length) return '';
+  const oldest = releases.all[releases.all.length - 1];
+  const d = new Date(oldest.date);
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+})();
+</script>
+
+<template>
+  <div class="rel-stats" v-if="latest">
+    <div class="rel-stat">
+      <div class="rel-stat-key">Latest release</div>
+      <div class="rel-stat-value">{{ latest.version }}</div>
+      <div class="rel-stat-sub">{{ latest.dateShort }}</div>
+    </div>
+    <div class="rel-stat">
+      <div class="rel-stat-key">Total releases</div>
+      <div class="rel-stat-value rel-stat-accent">{{ totalCount }}</div>
+      <div class="rel-stat-sub">since {{ sinceLabel }}</div>
+    </div>
+    <div class="rel-stat" v-if="cadenceDays !== null">
+      <div class="rel-stat-key">Cadence</div>
+      <div class="rel-stat-value">~{{ cadenceDays }}d</div>
+      <div class="rel-stat-sub">avg between ships</div>
+    </div>
+  </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1220,141 +1220,406 @@ a.blog-card:hover {
   background: var(--vp-c-warning-soft, rgba(196, 106, 0, 0.12));
 }
 
-/* Detail page hero — dark gradient card around version, badge, date-meta */
-.release-detail-page .vp-doc > div {
-  position: relative;
+/* ========== Releases — page-level layout overrides ========== */
+/* Both releases-index-page and release-detail-page use layout:page.
+   Hide the sidebar entirely and reclaim the space. */
+
+.releases-index-page .VPSidebar,
+.release-detail-page .VPSidebar,
+.releases-index-page .VPLocalNav,
+.release-detail-page .VPLocalNav {
+  display: none !important;
 }
 
-.release-detail-page .vp-doc > div::before {
+.releases-index-page .VPContent,
+.release-detail-page .VPContent,
+.releases-index-page .VPContent.has-sidebar,
+.release-detail-page .VPContent.has-sidebar {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+  margin: 0 !important;
+}
+
+.releases-index-page .VPPage,
+.release-detail-page .VPPage {
+  padding: 0;
+  max-width: none;
+}
+
+/* Index page: content is in <div style="position:relative;"><div>...</div></div> */
+.releases-index-page .VPPage > div {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+/* Index page: keep stats/hero/timeline at full width */
+.releases-index-page .releases-page-head,
+.releases-index-page .rel-stats,
+.releases-index-page .rel-latest-hero,
+.releases-index-page .releases-timeline {
+  max-width: 1080px;
+}
+
+/* ========== Release Detail Page (Redesigned) ========== */
+/* Layout: hero spans full width, then 2-col (content + sidebar) below */
+.release-detail-page .VPPage {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'hero'
+    'main'
+    'side';
+  background: var(--vp-c-bg);
+}
+
+.release-detail-page .VPPage > section.rel-detail-hero {
+  grid-area: hero;
+}
+
+/* Markdown content lives in <div style="position:relative;"> */
+.release-detail-page .VPPage > div {
+  grid-area: main;
+  padding: 3rem 1.5rem 4rem;
+  max-width: 760px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.release-detail-page .VPPage > aside.rel-detail-side {
+  grid-area: side;
+}
+
+@media (min-width: 960px) {
+  .release-detail-page .VPPage {
+    grid-template-columns: minmax(0, 1fr) 280px;
+    grid-template-areas:
+      'hero hero'
+      'main side';
+    column-gap: 3rem;
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+  }
+
+  .release-detail-page .VPPage > div {
+    padding: 3rem 0 4rem;
+    max-width: none;
+  }
+
+  .release-detail-page .VPPage > section.rel-detail-hero {
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+
+  .release-detail-page .VPPage > aside.rel-detail-side {
+    padding: 3rem 0 4rem;
+  }
+}
+
+/* Dark hero — full bleed */
+.rel-detail-hero {
+  background: linear-gradient(160deg, #060607 0%, #1a1a1f 100%);
+  color: #f5f5f7;
+  padding: 3.5rem 1.5rem 4.5rem;
+  position: relative;
+  overflow: hidden;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.rel-detail-hero::before {
   content: '';
   position: absolute;
-  top: -2.5rem;
-  left: -2rem;
-  right: -2rem;
-  height: 18rem;
+  inset: 0;
   background:
-    radial-gradient(ellipse 500px 280px at 85% 20%, rgba(82, 39, 219, 0.22) 0%, transparent 60%),
-    radial-gradient(ellipse 400px 240px at 5% 100%, rgba(180, 71, 217, 0.18) 0%, transparent 60%),
-    linear-gradient(160deg, #060607 0%, #1a1a1f 100%);
-  border-radius: 24px;
-  z-index: 0;
+    radial-gradient(ellipse 700px 400px at 80% 20%, rgba(82, 39, 219, 0.22) 0%, transparent 60%),
+    radial-gradient(ellipse 600px 300px at 0% 100%, rgba(180, 71, 217, 0.18) 0%, transparent 60%);
   pointer-events: none;
 }
 
-.release-detail-page .vp-doc > div > * {
+.rel-detail-hero-inner {
   position: relative;
-  z-index: 1;
+  max-width: 1080px;
+  margin: 0 auto;
 }
 
-.release-detail-page .vp-doc > div > h1 {
-  font-family: var(--vp-font-family-mono);
-  font-size: clamp(2.5rem, 6vw, 4.25rem);
+/* Breadcrumb */
+.rel-detail-breadcrumb {
+  font-size: 0.85rem;
+  color: #86868b;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 1.75rem;
+  flex-wrap: wrap;
+}
+
+.rel-detail-breadcrumb a {
+  color: #4ea7ff;
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.rel-detail-breadcrumb a:hover {
+  color: #79c0ff;
+  text-decoration: none;
+}
+
+.rel-detail-breadcrumb .sep {
+  color: #424245;
+}
+
+.rel-detail-breadcrumb .current {
+  color: #d2d2d7;
+}
+
+/* Status pill */
+.rel-detail-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  padding: 0.36rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #d2d2d7;
+  letter-spacing: 0.02em;
+  margin-bottom: 1.5rem;
+}
+
+.rel-detail-tag.is-alpha {
+  border-color: rgba(196, 106, 0, 0.4);
+  color: #ffd478;
+}
+
+.rel-detail-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #1f8b4c;
+  box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.6);
+  animation: rel-detail-pulse 2s infinite;
+}
+
+@keyframes rel-detail-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 0 8px rgba(31, 139, 76, 0);
+  }
+}
+
+/* Big version */
+.rel-detail-version {
+  font-family: var(--vp-font-family-base);
+  font-size: clamp(3.5rem, 9vw, 7rem);
   font-weight: 700;
   letter-spacing: -0.045em;
   line-height: 0.95;
-  margin: 1.5rem 0 1.25rem;
-  border-top: none;
-  padding-top: 0;
+  margin: 0 0 1.25rem;
   background: linear-gradient(180deg, #ffffff 0%, #b3b7c3 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
-.release-detail-page .vp-doc > div > h1 .header-anchor {
-  -webkit-text-fill-color: rgba(255, 255, 255, 0.4);
-  background: none;
-}
-
-/* Status pill — light text on dark, with green pulse for latest */
-.release-detail-page .vp-doc > div > h1 + p {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.release-detail-page .vp-doc > div > h1 + p .release-badge {
-  font-size: 0.72rem;
-  padding: 0.32rem 0.85rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+/* Headline */
+.rel-detail-headline {
+  font-size: 1.4rem;
+  line-height: 1.4;
   color: #d2d2d7;
-  gap: 0.45rem;
+  letter-spacing: -0.012em;
+  font-weight: 400;
+  max-width: 56ch;
+  margin: 0 0 2rem;
 }
 
-.release-detail-page .vp-doc > div > h1 + p .release-badge.latest::before {
-  content: '';
-  width: 6px;
-  height: 6px;
+/* CTAs */
+.rel-detail-cta-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.rel-detail-cta-primary,
+.rel-detail-cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  padding: 0 1.5rem;
   border-radius: 999px;
-  background: #1f8b4c;
-  display: inline-block;
-  box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
-  animation: rel-detail-pulse 2s infinite;
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-decoration: none;
+  letter-spacing: -0.005em;
+  white-space: nowrap;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
 }
 
-.release-detail-page .vp-doc > div > h1 + p .release-badge.alpha {
-  color: #ffd478;
-  border-color: rgba(196, 106, 0, 0.4);
-  background: rgba(196, 106, 0, 0.18);
+.rel-detail-cta-primary {
+  background: #fff;
+  color: #060607;
 }
 
-@keyframes rel-detail-pulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
+.rel-detail-cta-primary:hover {
+  background: #e5e5e7;
+  text-decoration: none;
+}
+
+.rel-detail-cta-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f5f7;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.rel-detail-cta-secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-decoration: none;
+}
+
+/* Right sidebar (Quick download) */
+.rel-detail-side {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 1.5rem;
+  align-self: start;
+}
+
+@media (min-width: 960px) {
+  .rel-detail-side {
+    position: sticky;
+    top: 5rem;
   }
-  100% {
-    box-shadow: 0 0 0 6px rgba(31, 139, 76, 0);
-  }
 }
 
-/* Date meta on dark — light text, divider strip */
-.release-detail-page .release-date-meta {
-  font-family: var(--vp-font-family-mono);
-  font-size: 0.875rem;
-  color: #a1a1a6;
-  margin: 0.5rem 0 4rem;
-  padding-bottom: 1.75rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  letter-spacing: 0.01em;
+.rel-detail-quick-download,
+.rel-detail-side-section {
+  background: var(--vp-c-bg-elv, var(--vp-c-bg));
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.03),
+    0 4px 12px rgba(0, 0, 0, 0.03);
 }
 
-/* Fallback for any release detail not getting the pageClass */
-.vp-doc:has(.release-date-meta):not(.release-detail-page .vp-doc) > div > h1 {
-  font-family: var(--vp-font-family-mono);
-  font-size: clamp(2.5rem, 6vw, 4.25rem);
-  font-weight: 700;
-  letter-spacing: -0.045em;
-  line-height: 0.95;
-  margin: 1rem 0;
-  border-top: none;
-  padding-top: 0;
+.rel-detail-quick-download h5,
+.rel-detail-side-section h5 {
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin: 0 0 0.85rem;
   color: var(--vp-c-text-1);
+  letter-spacing: -0.005em;
 }
 
-.release-date-meta {
+.rel-detail-download-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.rel-detail-download-row:first-of-type {
+  border-top: none;
+}
+
+.rel-detail-download-row .rel-detail-download-name {
+  color: var(--vp-c-text-2);
+}
+
+.rel-detail-download-row a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  font-weight: 500;
   font-family: var(--vp-font-family-mono);
-  font-size: 0.875rem;
-  color: var(--vp-c-text-3);
-  margin: 0.5rem 0 2.5rem;
-  padding-bottom: 1.5rem;
-  border-bottom: 1px solid var(--vp-c-divider);
-  letter-spacing: 0.01em;
+  font-size: 0.8rem;
 }
 
-/* Section headings on release detail pages */
-.vp-doc:has(.release-date-meta) h2 {
+.rel-detail-download-row a:hover {
+  text-decoration: underline;
+}
+
+.rel-detail-side-link a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.rel-detail-side-link a:hover {
+  text-decoration: underline;
+}
+
+/* Markdown content under hero — clean light page */
+/* Hide the markdown's own version heading, badge, and date strip
+   since the hero already shows them */
+.release-detail-page .VPPage > div h1[id] {
+  display: none;
+}
+
+.release-detail-page .VPPage > div .release-badge,
+.release-detail-page .VPPage > div .release-date-meta {
+  display: none;
+}
+
+.release-detail-page .VPPage > div p:has(> .release-badge) {
+  display: none;
+}
+
+/* Section headings — numbered cards effect */
+.release-detail-page .VPPage > div > div {
+  counter-reset: rel-section;
+}
+
+.release-detail-page .VPPage > div h2 {
+  counter-increment: rel-section;
   font-size: 1.5rem;
   font-weight: 600;
   letter-spacing: -0.02em;
-  margin-top: 2.75rem;
-  margin-bottom: 1.1rem;
+  margin-top: 3rem;
+  margin-bottom: 1.25rem;
   padding-top: 0;
   padding-bottom: 0;
   border-top: none;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   color: var(--vp-c-text-1);
 }
 
-.vp-doc:has(.release-date-meta) h3 {
+.release-detail-page .VPPage > div h2::before {
+  content: counter(rel-section, decimal-leading-zero);
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 10px;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+  display: inline-grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+
+.release-detail-page .VPPage > div h2:first-of-type {
+  margin-top: 0;
+}
+
+.release-detail-page .VPPage > div h2 .header-anchor {
+  margin-left: auto;
+}
+
+.release-detail-page .VPPage > div h3 {
   font-size: 1.1rem;
   font-weight: 600;
   letter-spacing: -0.012em;
@@ -1363,32 +1628,43 @@ a.blog-card:hover {
   color: var(--vp-c-text-1);
 }
 
-/* Body lists */
-.vp-doc:has(.release-date-meta) ul {
-  margin-top: 0.5rem;
-  padding-left: 1.25rem;
+.release-detail-page .VPPage > div ul {
+  margin: 0.5rem 0 1.5rem;
+  padding-left: 1.5rem;
 }
 
-.vp-doc:has(.release-date-meta) ul li {
+.release-detail-page .VPPage > div ul li {
   font-size: 0.95rem;
   line-height: 1.65;
   color: var(--vp-c-text-2);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.55rem;
   letter-spacing: -0.003em;
 }
 
-.vp-doc:has(.release-date-meta) ul li strong {
+.release-detail-page .VPPage > div ul li strong {
   color: var(--vp-c-text-1);
   font-weight: 600;
 }
 
-.vp-doc:has(.release-date-meta) ul li code {
+.release-detail-page .VPPage > div :not(pre) > code {
   font-family: var(--vp-font-family-mono);
   font-size: 0.85em;
   background: var(--vp-c-bg-soft);
   border: 1px solid var(--vp-c-divider);
-  padding: 0.08rem 0.4rem;
+  padding: 0.06rem 0.4rem;
   border-radius: 5px;
+  color: var(--vp-c-text-1);
+}
+
+/* Legacy date-meta styling for any non-detail context */
+.release-date-meta {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.875rem;
+  color: var(--vp-c-text-3);
+  margin: 0.5rem 0 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  letter-spacing: 0.01em;
 }
 
 /* Legacy classes preserved for backward compatibility */

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -374,9 +374,9 @@ a.blog-card:hover {
   display: none;
 }
 
-/* Release card */
+/* Release card — elevated surface, soft shadow, hover lift */
 .release-list-item {
-  background: var(--vp-c-bg);
+  background: var(--vp-c-bg-elv, var(--vp-c-bg));
   border: 1px solid var(--vp-c-divider);
   border-radius: 18px;
   padding: 1.75rem 2rem;
@@ -391,7 +391,6 @@ a.blog-card:hover {
 }
 
 .release-list-item:last-child {
-  border-bottom: 1px solid var(--vp-c-divider);
   margin-bottom: 0;
 }
 
@@ -406,7 +405,9 @@ a.blog-card:hover {
 /* Latest release: subtle accent gradient header */
 .release-list-item:has(.release-badge.latest) {
   border-color: var(--vp-c-brand-soft);
-  background: linear-gradient(180deg, var(--vp-c-brand-soft) 0%, transparent 96px), var(--vp-c-bg);
+  background:
+    linear-gradient(180deg, var(--vp-c-brand-soft) 0%, transparent 96px),
+    var(--vp-c-bg-elv, var(--vp-c-bg));
 }
 
 .release-list-item:has(.release-badge.latest):hover {
@@ -456,10 +457,21 @@ a.blog-card:hover {
 
 .release-list-item .release-excerpt {
   color: var(--vp-c-text-2);
-  font-size: 0.95rem;
-  line-height: 1.55;
-  letter-spacing: -0.005em;
+  font-size: 1.05rem;
+  line-height: 1.45;
+  letter-spacing: -0.012em;
+  font-weight: 400;
   margin: 0;
+}
+
+.release-list-item .release-excerpt code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85em;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  padding: 0.06rem 0.36rem;
+  border-radius: 5px;
+  color: var(--vp-c-text-1);
 }
 
 /* ========== Divider ========== */
@@ -913,7 +925,15 @@ a.blog-card:hover {
   margin: 1rem 0 1rem;
   border-top: none;
   padding-top: 0;
-  color: var(--vp-c-text-1);
+  background: linear-gradient(180deg, var(--vp-c-text-1) 0%, var(--vp-c-text-2) 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.vp-doc:has(.release-date-meta) > div > h1 .header-anchor {
+  -webkit-text-fill-color: var(--vp-c-text-3);
+  background: none;
 }
 
 /* Badge sits between version and date on detail pages */

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -346,32 +346,338 @@ a.blog-card:hover {
 }
 
 /* ========== Release List Page (Redesigned) ========== */
-/* Page-level treatment for the release index page, scoped via :has() */
-.vp-doc:has(.release-list-item) > div > h1 {
-  font-family: var(--vp-font-family-base);
-  font-size: clamp(2.25rem, 5vw, 3.75rem);
-  font-weight: 700;
-  letter-spacing: -0.035em;
-  line-height: 1.05;
-  margin: 0.5rem 0 1rem;
-  border-top: none;
-  padding-top: 0;
-  text-align: center;
+/* Page header: eyebrow + gradient title + sub */
+.releases-index-page .vp-doc {
+  --release-content-max: 880px;
 }
 
-.vp-doc:has(.release-list-item) > div > p:first-of-type {
+.releases-page-head {
   text-align: center;
-  font-size: 1.2rem;
+  padding: 1.5rem 0 2.5rem;
+  max-width: var(--release-content-max, 880px);
+  margin: 0 auto;
+}
+
+.releases-page-head .releases-eyebrow {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vp-c-brand-1);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.releases-page-head h1 {
+  font-family: var(--vp-font-family-base);
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.05;
+  margin: 0 auto 1rem;
+  border-top: none;
+  padding-top: 0;
+  max-width: 18ch;
+  color: var(--vp-c-text-1);
+}
+
+.releases-page-head h1 em {
+  font-style: normal;
+  background: linear-gradient(
+    120deg,
+    var(--vp-c-brand-1) 0%,
+    #a855f7 35%,
+    #ec4899 70%,
+    #f97316 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.releases-page-head .releases-page-sub {
+  font-size: 1.15rem;
   color: var(--vp-c-text-2);
   max-width: 56ch;
-  margin: 0 auto 2.75rem;
-  line-height: 1.4;
+  margin: 0 auto;
+  line-height: 1.45;
   letter-spacing: -0.012em;
   font-weight: 400;
 }
 
-.vp-doc:has(.release-list-item) > div > hr {
+.releases-index-page .vp-doc > div > hr {
   display: none;
+}
+
+/* Stats strip */
+.rel-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin: 0 auto 3rem;
+  max-width: var(--release-content-max, 880px);
+}
+
+.rel-stat {
+  background: var(--vp-c-bg-elv, var(--vp-c-bg));
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  padding: 1.25rem 1.5rem;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.03),
+    0 4px 12px rgba(0, 0, 0, 0.03);
+}
+
+.rel-stat-key {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--vp-c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.rel-stat-value {
+  font-family: var(--vp-font-family-mono);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1;
+  color: var(--vp-c-text-1);
+}
+
+.rel-stat-value.rel-stat-accent {
+  background: linear-gradient(135deg, var(--vp-c-brand-1) 0%, #a855f7 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.rel-stat-sub {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.78rem;
+  color: var(--vp-c-text-3);
+  margin-top: 0.4rem;
+}
+
+/* Latest hero — dark gradient panel */
+.rel-latest-hero {
+  background: linear-gradient(160deg, #060607 0%, #1a1a1f 100%);
+  color: #f5f5f7;
+  border-radius: 24px;
+  padding: 2.5rem;
+  margin: 0 auto 2.5rem;
+  position: relative;
+  overflow: hidden;
+  max-width: var(--release-content-max, 880px);
+}
+
+.rel-latest-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 500px 300px at 80% 0%, rgba(82, 39, 219, 0.28) 0%, transparent 60%),
+    radial-gradient(ellipse 500px 300px at 0% 100%, rgba(180, 71, 217, 0.2) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.rel-latest-hero-inner {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.rel-latest-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #d2d2d7;
+  letter-spacing: 0.02em;
+  margin-bottom: 1.1rem;
+}
+
+.rel-latest-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #1f8b4c;
+  box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
+  animation: rel-latest-pulse 2s infinite;
+}
+
+@keyframes rel-latest-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 8px rgba(31, 139, 76, 0);
+  }
+}
+
+.rel-latest-version {
+  font-family: var(--vp-font-family-base);
+  font-size: clamp(3rem, 7vw, 5rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin: 0 0 0.85rem;
+  background: linear-gradient(180deg, #ffffff 0%, #b3b7c3 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.rel-latest-headline {
+  font-size: 1.2rem;
+  color: #d2d2d7;
+  line-height: 1.4;
+  margin: 0 0 1.5rem;
+  letter-spacing: -0.012em;
+}
+
+.rel-latest-cta-row {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.rel-latest-cta-primary,
+.rel-latest-cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  padding: 0 1.1rem;
+  border-radius: 999px;
+  font-size: 0.92rem;
+  font-weight: 500;
+  text-decoration: none;
+  letter-spacing: -0.005em;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+}
+
+.rel-latest-cta-primary {
+  background: #fff;
+  color: #060607;
+}
+
+.rel-latest-cta-primary:hover {
+  background: #e5e5e7;
+  text-decoration: none;
+}
+
+.rel-latest-cta-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f5f7;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.rel-latest-cta-secondary:hover {
+  background: rgba(255, 255, 255, 0.1);
+  text-decoration: none;
+}
+
+.rel-latest-hero-summary {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.25rem 1.4rem;
+  backdrop-filter: blur(20px);
+}
+
+.rel-latest-hero-summary h4 {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #a1a1a6;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0 0 0.85rem;
+  border-top: none;
+  padding-top: 0;
+}
+
+.rel-latest-hero-summary ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.88rem;
+  color: #d2d2d7;
+}
+
+.rel-latest-hero-summary li {
+  padding: 0.3rem 0 0.3rem 1.4rem;
+  line-height: 1.4;
+  position: relative;
+  letter-spacing: -0.005em;
+}
+
+.rel-latest-hero-summary li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  top: 0.32rem;
+  color: #4ea7ff;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+}
+
+.rel-latest-hero-summary li code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85em;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  color: #f5f5f7;
+}
+
+/* Timeline — vertical line + dots running down the cards */
+.releases-timeline {
+  position: relative;
+  padding-left: 2rem;
+  max-width: var(--release-content-max, 880px);
+  margin: 0 auto;
+}
+
+.releases-timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;
+  top: 1.75rem;
+  bottom: 1.75rem;
+  width: 2px;
+  background: linear-gradient(180deg, var(--vp-c-divider) 0%, transparent 100%);
+}
+
+.releases-timeline .release-list-item {
+  position: relative;
+}
+
+.releases-timeline .release-list-item::before {
+  content: '';
+  position: absolute;
+  left: -2rem;
+  top: 1.75rem;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--vp-c-bg);
+  border: 2px solid var(--vp-c-text-3);
+  box-sizing: border-box;
+  z-index: 1;
+}
+
+.releases-timeline .release-list-item:has(.release-badge.alpha)::before {
+  border-color: var(--vp-c-warning-1, #c46a00);
 }
 
 /* Release card — elevated surface, soft shadow, hover lift */
@@ -915,39 +1221,117 @@ a.blog-card:hover {
   background: var(--vp-c-warning-soft, rgba(196, 106, 0, 0.12));
 }
 
-/* Release detail header — scoped via :has(.release-date-meta) */
-.vp-doc:has(.release-date-meta) > div > h1 {
+/* Detail page hero — dark gradient card around version, badge, date-meta */
+.release-detail-page .vp-doc > div {
+  position: relative;
+}
+
+.release-detail-page .vp-doc > div::before {
+  content: '';
+  position: absolute;
+  top: -2.5rem;
+  left: -2rem;
+  right: -2rem;
+  height: 18rem;
+  background:
+    radial-gradient(ellipse 500px 280px at 85% 20%, rgba(82, 39, 219, 0.22) 0%, transparent 60%),
+    radial-gradient(ellipse 400px 240px at 5% 100%, rgba(180, 71, 217, 0.18) 0%, transparent 60%),
+    linear-gradient(160deg, #060607 0%, #1a1a1f 100%);
+  border-radius: 24px;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.release-detail-page .vp-doc > div > * {
+  position: relative;
+  z-index: 1;
+}
+
+.release-detail-page .vp-doc > div > h1 {
   font-family: var(--vp-font-family-mono);
   font-size: clamp(2.5rem, 6vw, 4.25rem);
   font-weight: 700;
   letter-spacing: -0.045em;
   line-height: 0.95;
-  margin: 1rem 0 1rem;
+  margin: 1.5rem 0 1.25rem;
   border-top: none;
   padding-top: 0;
-  background: linear-gradient(180deg, var(--vp-c-text-1) 0%, var(--vp-c-text-2) 95%);
+  background: linear-gradient(180deg, #ffffff 0%, #b3b7c3 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
-.vp-doc:has(.release-date-meta) > div > h1 .header-anchor {
-  -webkit-text-fill-color: var(--vp-c-text-3);
+.release-detail-page .vp-doc > div > h1 .header-anchor {
+  -webkit-text-fill-color: rgba(255, 255, 255, 0.4);
   background: none;
 }
 
-/* Badge sits between version and date on detail pages */
-.vp-doc:has(.release-date-meta) > div > h1 + p {
+/* Status pill — light text on dark, with green pulse for latest */
+.release-detail-page .vp-doc > div > h1 + p {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
 
-.vp-doc:has(.release-date-meta) > div > h1 + p .release-badge {
+.release-detail-page .vp-doc > div > h1 + p .release-badge {
   font-size: 0.72rem;
-  padding: 0.28rem 0.8rem;
+  padding: 0.32rem 0.85rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: #d2d2d7;
+  gap: 0.45rem;
 }
 
-/* Date meta — divider strip below the header */
+.release-detail-page .vp-doc > div > h1 + p .release-badge.latest::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #1f8b4c;
+  display: inline-block;
+  box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
+  animation: rel-detail-pulse 2s infinite;
+}
+
+.release-detail-page .vp-doc > div > h1 + p .release-badge.alpha {
+  color: #ffd478;
+  border-color: rgba(196, 106, 0, 0.4);
+  background: rgba(196, 106, 0, 0.18);
+}
+
+@keyframes rel-detail-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(31, 139, 76, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 6px rgba(31, 139, 76, 0);
+  }
+}
+
+/* Date meta on dark — light text, divider strip */
+.release-detail-page .release-date-meta {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.875rem;
+  color: #a1a1a6;
+  margin: 0.5rem 0 4rem;
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  letter-spacing: 0.01em;
+}
+
+/* Fallback for any release detail not getting the pageClass */
+.vp-doc:has(.release-date-meta):not(.release-detail-page .vp-doc) > div > h1 {
+  font-family: var(--vp-font-family-mono);
+  font-size: clamp(2.5rem, 6vw, 4.25rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin: 1rem 0;
+  border-top: none;
+  padding-top: 0;
+  color: var(--vp-c-text-1);
+}
+
 .release-date-meta {
   font-family: var(--vp-font-family-mono);
   font-size: 0.875rem;
@@ -1114,6 +1498,47 @@ html.dark .release-badge.alpha {
 
   .vp-doc:has(.release-date-meta) > div > h1 {
     font-size: clamp(2.25rem, 9vw, 3rem);
+  }
+
+  .rel-stats {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .rel-stats .rel-stat:nth-child(3) {
+    grid-column: 1 / -1;
+  }
+
+  .rel-latest-hero {
+    padding: 1.75rem 1.5rem;
+    border-radius: 18px;
+  }
+
+  .rel-latest-hero-inner {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .releases-timeline {
+    padding-left: 1.5rem;
+  }
+
+  .releases-timeline::before {
+    left: 0;
+  }
+
+  .releases-timeline .release-list-item::before {
+    left: -1.5rem;
+  }
+
+  .releases-page-head {
+    padding: 1rem 0 1.5rem;
+  }
+
+  .release-detail-page .vp-doc > div::before {
+    left: -1rem;
+    right: -1rem;
+    height: 16rem;
+    border-radius: 16px;
   }
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -359,11 +359,10 @@ a.blog-card:hover {
 }
 
 .releases-page-head .releases-eyebrow {
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   font-weight: 600;
-  color: var(--vp-c-brand-1);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+  letter-spacing: -0.005em;
   margin-bottom: 1rem;
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -345,14 +345,77 @@ a.blog-card:hover {
   line-height: 1.6;
 }
 
-/* ========== Release List Page ========== */
+/* ========== Release List Page (Redesigned) ========== */
+/* Page-level treatment for the release index page, scoped via :has() */
+.vp-doc:has(.release-list-item) > div > h1 {
+  font-family: var(--vp-font-family-base);
+  font-size: clamp(2.25rem, 5vw, 3.75rem);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+  margin: 0.5rem 0 1rem;
+  border-top: none;
+  padding-top: 0;
+  text-align: center;
+}
+
+.vp-doc:has(.release-list-item) > div > p:first-of-type {
+  text-align: center;
+  font-size: 1.2rem;
+  color: var(--vp-c-text-2);
+  max-width: 56ch;
+  margin: 0 auto 2.75rem;
+  line-height: 1.4;
+  letter-spacing: -0.012em;
+  font-weight: 400;
+}
+
+.vp-doc:has(.release-list-item) > div > hr {
+  display: none;
+}
+
+/* Release card */
 .release-list-item {
-  padding: 1.5rem 0;
-  border-bottom: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 18px;
+  padding: 1.75rem 2rem;
+  margin: 0 0 0.85rem;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.03),
+    0 4px 12px rgba(0, 0, 0, 0.03);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .release-list-item:last-child {
-  border-bottom: none;
+  border-bottom: 1px solid var(--vp-c-divider);
+  margin-bottom: 0;
+}
+
+.release-list-item:hover {
+  border-color: var(--vp-c-text-3);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.06),
+    0 24px 48px -12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+/* Latest release: subtle accent gradient header */
+.release-list-item:has(.release-badge.latest) {
+  border-color: var(--vp-c-brand-soft);
+  background: linear-gradient(180deg, var(--vp-c-brand-soft) 0%, transparent 96px), var(--vp-c-bg);
+}
+
+.release-list-item:has(.release-badge.latest):hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+/* Alpha release: muted look */
+.release-list-item:has(.release-badge.alpha) {
+  background: var(--vp-c-bg-soft);
 }
 
 .release-list-item a {
@@ -361,11 +424,15 @@ a.blog-card:hover {
 }
 
 .release-list-item h2 {
-  font-size: 1.3rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 1.4rem;
   font-weight: 600;
-  margin-bottom: 0.4rem;
+  letter-spacing: -0.015em;
+  margin: 0 0 0.5rem;
   border-top: none;
   padding-top: 0;
+  color: var(--vp-c-text-1);
+  transition: color 160ms ease;
 }
 
 .release-list-item h2:hover {
@@ -373,23 +440,26 @@ a.blog-card:hover {
 }
 
 .release-list-item .release-meta {
-  font-size: 0.8rem;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.78rem;
   color: var(--vp-c-text-3);
-  margin-bottom: 0.5rem;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  margin: 0 0 0.95rem;
 }
 
 .release-list-item .release-meta .release-badge {
-  font-size: 0.7rem;
-  padding: 0.1rem 0.5rem;
+  font-size: 0.65rem;
+  padding: 0.18rem 0.6rem;
 }
 
 .release-list-item .release-excerpt {
   color: var(--vp-c-text-2);
-  font-size: 0.92rem;
-  line-height: 1.6;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  letter-spacing: -0.005em;
+  margin: 0;
 }
 
 /* ========== Divider ========== */
@@ -809,7 +879,116 @@ a.blog-card:hover {
   }
 }
 
-/* ========== Release Notes ========== */
+/* ========== Release Detail Page (Redesigned) ========== */
+/* Pill-shaped badges, used on both index and detail pages */
+.release-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.22rem 0.7rem;
+  border-radius: 999px;
+  font-family: var(--vp-font-family-base);
+}
+
+.release-badge.latest {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+
+.release-badge.alpha {
+  color: var(--vp-c-warning-1, #c46a00);
+  background: var(--vp-c-warning-soft, rgba(196, 106, 0, 0.12));
+}
+
+/* Release detail header — scoped via :has(.release-date-meta) */
+.vp-doc:has(.release-date-meta) > div > h1 {
+  font-family: var(--vp-font-family-mono);
+  font-size: clamp(2.5rem, 6vw, 4.25rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin: 1rem 0 1rem;
+  border-top: none;
+  padding-top: 0;
+  color: var(--vp-c-text-1);
+}
+
+/* Badge sits between version and date on detail pages */
+.vp-doc:has(.release-date-meta) > div > h1 + p {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.vp-doc:has(.release-date-meta) > div > h1 + p .release-badge {
+  font-size: 0.72rem;
+  padding: 0.28rem 0.8rem;
+}
+
+/* Date meta — divider strip below the header */
+.release-date-meta {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.875rem;
+  color: var(--vp-c-text-3);
+  margin: 0.5rem 0 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+  letter-spacing: 0.01em;
+}
+
+/* Section headings on release detail pages */
+.vp-doc:has(.release-date-meta) h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 2.75rem;
+  margin-bottom: 1.1rem;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top: none;
+  color: var(--vp-c-text-1);
+}
+
+.vp-doc:has(.release-date-meta) h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  margin-top: 1.5rem;
+  margin-bottom: 0.6rem;
+  color: var(--vp-c-text-1);
+}
+
+/* Body lists */
+.vp-doc:has(.release-date-meta) ul {
+  margin-top: 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.vp-doc:has(.release-date-meta) ul li {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--vp-c-text-2);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.003em;
+}
+
+.vp-doc:has(.release-date-meta) ul li strong {
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+}
+
+.vp-doc:has(.release-date-meta) ul li code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85em;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  padding: 0.08rem 0.4rem;
+  border-radius: 5px;
+}
+
+/* Legacy classes preserved for backward compatibility */
 .release-note {
   padding: 1.5rem 0;
   border-bottom: 1px solid var(--vp-c-divider);
@@ -831,32 +1010,6 @@ a.blog-card:hover {
   margin: 0;
   border-top: none;
   padding-top: 0;
-}
-
-.release-badge {
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.2rem 0.6rem;
-  border-radius: 4px;
-}
-
-.release-badge.latest {
-  color: var(--vp-c-brand-1);
-  background: var(--vp-c-brand-soft);
-}
-
-.release-badge.alpha {
-  color: var(--vp-c-warning-1, #e2a72e);
-  background: var(--vp-c-warning-soft, rgba(226, 167, 46, 0.12));
-}
-
-.release-date-meta {
-  font-size: 0.8rem;
-  color: var(--vp-c-text-3);
-  margin-bottom: 1rem;
-  margin-top: 0.25rem;
 }
 
 .release-note h3 {
@@ -884,6 +1037,28 @@ a.blog-card:hover {
   margin-bottom: 0.5rem;
 }
 
+/* Dark-mode tweaks for redesigned release pages */
+html.dark .release-list-item {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+html.dark .release-list-item:hover {
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.4),
+    0 24px 48px -12px rgba(0, 0, 0, 0.5);
+}
+
+html.dark .release-list-item:has(.release-badge.alpha) {
+  background: var(--vp-c-bg-soft);
+}
+
+html.dark .release-badge.alpha {
+  color: #e2a72e;
+  background: rgba(226, 167, 46, 0.16);
+}
+
 /* ========== Responsive ========== */
 @media (max-width: 768px) {
   .capsules-grid {
@@ -906,6 +1081,19 @@ a.blog-card:hover {
 
   .feature-capsules-inner {
     padding: 3rem 1rem 4rem;
+  }
+
+  .release-list-item {
+    padding: 1.25rem 1.25rem;
+    border-radius: 14px;
+  }
+
+  .release-list-item h2 {
+    font-size: 1.2rem;
+  }
+
+  .vp-doc:has(.release-date-meta) > div > h1 {
+    font-size: clamp(2.25rem, 9vw, 3rem);
   }
 }
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,8 @@ import FeatureCapsules from './components/FeatureCapsules.vue';
 import BlogList from './components/BlogList.vue';
 import HomeContent from './components/HomeContent.vue';
 import DownloadsPage from './components/DownloadsPage.vue';
+import ReleasesStats from './components/ReleasesStats.vue';
+import ReleasesLatestHero from './components/ReleasesLatestHero.vue';
 import './custom.css';
 
 export default {
@@ -15,5 +17,7 @@ export default {
     app.component('BlogList', BlogList);
     app.component('HomeContent', HomeContent);
     app.component('DownloadsPage', DownloadsPage);
+    app.component('ReleasesStats', ReleasesStats);
+    app.component('ReleasesLatestHero', ReleasesLatestHero);
   },
 } satisfies Theme;

--- a/docs/.vitepress/theme/releases.data.ts
+++ b/docs/.vitepress/theme/releases.data.ts
@@ -1,4 +1,7 @@
 import { createContentLoader } from 'vitepress';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 function formatDate(date: string | Date): string {
   return new Date(date).toLocaleDateString('en-US', {
@@ -16,6 +19,52 @@ function shortDate(date: string | Date): string {
   });
 }
 
+function loadHeadlinesFromIndex(): Map<string, string> {
+  const indexPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../releases/index.md');
+  const out = new Map<string, string>();
+  let content: string;
+  try {
+    content = readFileSync(indexPath, 'utf-8');
+  } catch {
+    return out;
+  }
+  // Extract release-list-item blocks: pair href with release-excerpt
+  const itemRe = /href="(\/releases\/[^"]+?)"[\s\S]*?<p class="release-excerpt">([\s\S]*?)<\/p>/g;
+  let match: RegExpExecArray | null;
+  while ((match = itemRe.exec(content))) {
+    const url = match[1].endsWith('/') ? match[1] : match[1] + '';
+    const text = match[2].replace(/\s+/g, ' ').trim();
+    out.set(url, text);
+  }
+  // Latest hero excerpt: first paragraph between <ReleasesLatestHero> and <template
+  const heroRe = /<ReleasesLatestHero[^>]*>([\s\S]*?)<template/;
+  const heroMatch = heroRe.exec(content);
+  if (heroMatch) {
+    const text = heroMatch[1].replace(/\s+/g, ' ').trim();
+    if (text) out.set('__latest__', text);
+  }
+  return out;
+}
+
+const indexHeadlines = loadHeadlinesFromIndex();
+
+function extractFirstParagraph(src: string): string {
+  if (!src) return '';
+  const body = src.replace(/^---\n[\s\S]*?\n---\n/, '');
+  const lines = body.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('#')) continue;
+    if (trimmed.startsWith('<')) continue;
+    if (trimmed.startsWith('-') || trimmed.startsWith('*')) continue;
+    if (trimmed.startsWith('```')) continue;
+    if (trimmed.startsWith('---')) continue;
+    return trimmed;
+  }
+  return '';
+}
+
 export interface ReleaseSummary {
   version: string;
   url: string;
@@ -24,6 +73,7 @@ export interface ReleaseSummary {
   dateShort: string;
   isAlpha: boolean;
   badge?: string;
+  headline: string;
 }
 
 export interface ReleasesData {
@@ -37,6 +87,7 @@ declare const data: ReleasesData;
 export { data };
 
 export default createContentLoader('releases/v*.md', {
+  includeSrc: true,
   transform(rawData): ReleasesData {
     const all = rawData
       .map<ReleaseSummary>((page) => {
@@ -47,6 +98,18 @@ export default createContentLoader('releases/v*.md', {
           typeof page.frontmatter.date === 'string'
             ? page.frontmatter.date
             : new Date(page.frontmatter.date as Date).toISOString().split('T')[0];
+
+        // Headline resolution order:
+        //   1) frontmatter.headline (explicit override)
+        //   2) <p class="release-excerpt"> from index.md
+        //   3) first paragraph in source body
+        //   4) generic placeholder
+        const fmHeadline = page.frontmatter.headline as string | undefined;
+        const indexHeadline = indexHeadlines.get(page.url);
+        const srcHeadline = extractFirstParagraph(page.src || '');
+        const headline =
+          fmHeadline || indexHeadline || srcHeadline || `Released ${formatDate(dateStr)}.`;
+
         return {
           version: title,
           url: page.url,
@@ -55,9 +118,16 @@ export default createContentLoader('releases/v*.md', {
           dateShort: shortDate(dateStr),
           isAlpha,
           badge,
+          headline,
         };
       })
       .sort((a, b) => +new Date(b.date) - +new Date(a.date));
+
+    // For the latest release, prefer the index.md hero excerpt over the cards
+    if (all.length > 0) {
+      const heroExcerpt = indexHeadlines.get('__latest__');
+      if (heroExcerpt) all[0].headline = heroExcerpt;
+    }
 
     let cadenceDays: number | null = null;
     if (all.length >= 2) {

--- a/docs/.vitepress/theme/releases.data.ts
+++ b/docs/.vitepress/theme/releases.data.ts
@@ -1,0 +1,77 @@
+import { createContentLoader } from 'vitepress';
+
+function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function shortDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export interface ReleaseSummary {
+  version: string;
+  url: string;
+  date: string;
+  dateLong: string;
+  dateShort: string;
+  isAlpha: boolean;
+  badge?: string;
+}
+
+export interface ReleasesData {
+  all: ReleaseSummary[];
+  latest: ReleaseSummary | null;
+  totalCount: number;
+  cadenceDays: number | null;
+}
+
+declare const data: ReleasesData;
+export { data };
+
+export default createContentLoader('releases/v*.md', {
+  transform(rawData): ReleasesData {
+    const all = rawData
+      .map<ReleaseSummary>((page) => {
+        const title = (page.frontmatter.title as string) || page.url.split('/').pop() || '';
+        const badge = page.frontmatter.badge as string | undefined;
+        const isAlpha = (badge || '').toLowerCase().includes('alpha') || /-alpha/.test(title);
+        const dateStr =
+          typeof page.frontmatter.date === 'string'
+            ? page.frontmatter.date
+            : new Date(page.frontmatter.date as Date).toISOString().split('T')[0];
+        return {
+          version: title,
+          url: page.url,
+          date: dateStr,
+          dateLong: formatDate(dateStr),
+          dateShort: shortDate(dateStr),
+          isAlpha,
+          badge,
+        };
+      })
+      .sort((a, b) => +new Date(b.date) - +new Date(a.date));
+
+    let cadenceDays: number | null = null;
+    if (all.length >= 2) {
+      const newest = +new Date(all[0].date);
+      const oldest = +new Date(all[all.length - 1].date);
+      const spanDays = (newest - oldest) / (1000 * 60 * 60 * 24);
+      cadenceDays = Math.round(spanDays / (all.length - 1));
+    }
+
+    return {
+      all,
+      latest: all[0] ?? null,
+      totalCount: all.length,
+      cadenceDays,
+    };
+  },
+});

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -3,19 +3,30 @@ title: 'Release Notes — Nav0 Browser'
 description: "Release notes and changelog for Nav0 Browser. See what's new in every release — features, fixes, and improvements."
 ---
 
-# Release Notes
+<div class="releases-page-head">
+  <div class="releases-eyebrow">Release notes</div>
 
-What's new in every release of Nav0 Browser.
+# Every <em>shipped</em> change, in one place.
 
----
-
-<div class="release-list-item">
-  <a href="/releases/v0.2.6">
-    <h2>v0.2.6</h2>
-  </a>
-  <div class="release-meta">May 6, 2026 <span class="release-badge latest">Latest</span></div>
-  <p class="release-excerpt">Fixed packaging breakage from the Electron 41 upgrade, restored Google sign-in by refreshing Firefox UA cap and Chrome preset, and softened the new-tab gradient background.</p>
+  <p class="releases-page-sub">Nav0 ships small and often. No "AI-powered" features hidden in patch notes — just real changes you can read in under a minute each.</p>
 </div>
+
+<ReleasesStats />
+
+<ReleasesLatestHero>
+Fixed packaging breakage from the Electron 41 upgrade, restored Google sign-in by refreshing Firefox UA cap and Chrome preset, and softened the new-tab gradient background.
+
+<template #summary>
+
+- Restored `package.json` `main` to `.webpack/main` so `electron-forge package` works again
+- Refreshed Firefox UA cap and widened Google sign-in host match
+- Bumped Chrome preset to Electron 41's Chromium 146
+- Softened new-tab pastel gradient to read essentially white at a glance
+
+</template>
+</ReleasesLatestHero>
+
+<div class="releases-timeline">
 
 <div class="release-list-item">
   <a href="/releases/v0.2.5">
@@ -159,4 +170,6 @@ What's new in every release of Nav0 Browser.
   </a>
   <div class="release-meta">February 12, 2026 <span class="release-badge alpha">Alpha</span></div>
   <p class="release-excerpt">First alpha release — Electron-based browser with Chromium engine, Command-K search, tab management, bookmarks, and download manager.</p>
+</div>
+
 </div>


### PR DESCRIPTION
## Summary
Completely redesigns the releases index and detail pages with modern hero sections, stats strips, timeline layouts, and improved visual hierarchy. Introduces a data loader to aggregate release metadata and new Vue components for consistent presentation across release pages.

## Key Changes

### Styling & Layout (`docs/.vitepress/theme/custom.css`)
- **Releases index page**: Added centered page header with eyebrow, gradient-text title, and subtitle; stats strip showing latest version, total releases, and cadence; dark gradient hero panel for latest release with CTA buttons; vertical timeline with dots for release cards
- **Release detail page**: Full-bleed dark hero with breadcrumb, status tag, large version number, headline, and CTAs; 2-column layout (content + sticky sidebar) on desktop; right sidebar with quick download links and navigation
- **Release cards**: Redesigned as elevated surfaces with rounded corners, soft shadows, hover lift effects, and accent styling for latest/alpha releases
- **Responsive**: Added mobile breakpoints for stats grid (2 cols), hero layout (single column), and timeline adjustments
- **Dark mode**: Enhanced shadows and color adjustments for dark theme

### Data & Components
- **`releases.data.ts`** (new): Content loader that aggregates release metadata from `releases/v*.md` files, extracts headlines from frontmatter/index/source, calculates release cadence, and exports typed `ReleasesData` interface
- **`ReleaseDetailHero.vue`** (new): Hero section for detail pages with breadcrumb, status tag, version, headline, and download/GitHub CTAs
- **`ReleaseDetailSidebar.vue`** (new): Right sidebar with quick download links and back-to-releases navigation
- **`ReleasesStats.vue`** (new): Stats strip showing latest version, total count, and release cadence
- **`ReleasesLatestHero.vue`** (new): Dark hero panel for latest release on index page with slot-based content

### Configuration & Layout
- **`config.ts`**: Added `pageClass` assignment for releases index and detail pages to enable CSS targeting
- **`Layout.vue`**: Conditional rendering of `ReleaseDetailHero` and `ReleaseDetailSidebar` for release detail pages; hides sidebar and local nav for release pages
- **`index.ts`**: Registered new release components globally

### Content
- **`releases/index.md`**: Restructured with new page header component, stats, latest hero, and timeline-wrapped release list

## Notable Implementation Details
- Release metadata is centrally managed via the data loader, supporting headline resolution order: frontmatter override → index.md excerpt → first paragraph in source → fallback
- Timeline uses CSS pseudo-elements (::before) for vertical line and dots, with color variants for alpha releases
- Hero sections use radial gradients and backdrop filters for visual depth
- All interactive elements include smooth transitions and hover states
- Layout uses CSS Grid for responsive 2-column detail page and flexible stats grid

https://claude.ai/code/session_01C9cju2R8pnpPQVaXGQ4L2F