### PR TITLE
Add stop loading functionality to refresh button

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -103,6 +103,7 @@ export abstract class RendererToMainEventsForBrowserIPC {
   public static readonly GO_FORWARD = 'browser:go-forward';
   public static readonly REFRESH = 'browser:refresh';
   public static readonly HARD_RELOAD = 'browser:hard-reload';
+  public static readonly STOP_LOADING = 'browser:stop-loading';
   public static readonly ADD_BOOKMARK = 'browser:add-bookmark';
   public static readonly REMOVE_BOOKMARK = 'browser:remove-bookmark';
   public static readonly REMOVE_ALL_BOOKMARKS = 'browser:remove-all-bookmarks';

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -483,6 +483,28 @@ export abstract class AppWindowManager {
     );
 
     ipcMain.handle(
+      RendererToMainEventsForBrowserIPC.STOP_LOADING,
+      async (event, appWindowId: string, tabId: string) => {
+        let appWindow: AppWindow;
+        let tab: Tab;
+        if (appWindowId) {
+          appWindow = AppWindowManager.getWindowById(appWindowId);
+        } else {
+          appWindow = AppWindowManager.getActiveWindow();
+        }
+        if (appWindow && tabId) {
+          tab = AppWindowManager.getWindowById(appWindowId).getTabById(tabId);
+        } else if (appWindow) {
+          tab = appWindow.getActiveTab();
+        }
+
+        if (tab && tab.getWebContentsViewInstance()) {
+          return tab.getWebContentsViewInstance().webContents.stop();
+        }
+      }
+    );
+
+    ipcMain.handle(
       RendererToMainEventsForBrowserIPC.UPDATE_BROWSER_VIEW_BOUNDS,
       async (
         event,

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -76,6 +76,13 @@ export function init() {
     hardReloadTab: async (appWindowId: string, tabId: string) => {
       return ipcRenderer.invoke(RendererToMainEventsForBrowserIPC.HARD_RELOAD, appWindowId, tabId);
     },
+    stopLoadingTab: async (appWindowId: string, tabId: string) => {
+      return ipcRenderer.invoke(
+        RendererToMainEventsForBrowserIPC.STOP_LOADING,
+        appWindowId,
+        tabId
+      );
+    },
     addBookmark: async (
       appWindowId: string,
       title: string,

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -112,9 +112,12 @@ export class BrowserTabManager {
       window.BrowserAPI.goForward(this.appWindowId, this.activeTabId);
     });
 
-    // Refresh button (shift+click for hard reload)
+    // Refresh button (shift+click for hard reload, click to stop while loading)
     this.refreshButton.addEventListener('click', (e: MouseEvent) => {
-      if (e.shiftKey) {
+      const activeTab = this.getTabById(this.activeTabId);
+      if (activeTab?.isLoading) {
+        window.BrowserAPI.stopLoadingTab(this.appWindowId, this.activeTabId);
+      } else if (e.shiftKey) {
         window.BrowserAPI.hardReloadTab(this.appWindowId, this.activeTabId);
       } else {
         window.BrowserAPI.refreshTab(this.appWindowId, this.activeTabId);
@@ -217,6 +220,7 @@ export class BrowserTabManager {
       this.handleBookmark();
       this.updateReaderModeButton();
       this.updateSSLIndicator();
+      this.updateRefreshButton();
     });
 
     // Tab closed
@@ -293,6 +297,9 @@ export class BrowserTabManager {
     // Tab loading state changed
     window.BrowserAPI.onTabLoadingChanged((data: { id: string; isLoading: boolean }) => {
       this.getTabById(data.id)?.setLoading(data.isLoading);
+      if (data.id === this.activeTabId) {
+        this.updateRefreshButton();
+      }
     });
 
     // Download progress tracking
@@ -515,6 +522,24 @@ export class BrowserTabManager {
     const el = activeTab?.getTabElement();
     if (el) {
       el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+    }
+  }
+
+  // Inline SVG strings for the refresh/stop toggle on the nav bar
+  private static readonly REFRESH_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>';
+  private static readonly STOP_ICON =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+
+  private updateRefreshButton(): void {
+    const activeTab = this.getTabById(this.activeTabId);
+    const isLoading = !!activeTab?.isLoading;
+    if (isLoading) {
+      this.refreshButton.innerHTML = BrowserTabManager.STOP_ICON;
+      this.refreshButton.title = 'Stop loading';
+    } else {
+      this.refreshButton.innerHTML = BrowserTabManager.REFRESH_ICON;
+      this.refreshButton.title = 'Refresh';
     }
   }
 

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -25,6 +25,7 @@ declare global {
       goForward: (appWindowId: string, tabId: string) => Promise<any>;
       refreshTab: (appWindowId: string, tabId: string) => Promise<any>;
       hardReloadTab: (appWindowId: string, tabId: string) => Promise<any>;
+      stopLoadingTab: (appWindowId: string, tabId: string) => Promise<any>;
       addBookmark: (
         appWindowId: string,
         title: string,


### PR DESCRIPTION
## Summary
This PR adds the ability to stop page loading by clicking the refresh button while a page is loading. The refresh button now toggles between a refresh icon and a stop icon based on the loading state of the active tab.

## Key Changes
- **Refresh button behavior**: Modified click handler to check if the active tab is loading and call `stopLoadingTab()` instead of refresh when a page is loading
- **Visual feedback**: Added `updateRefreshButton()` method that toggles the button icon and tooltip between refresh and stop states based on tab loading status
- **Icon assets**: Added inline SVG definitions for both refresh and stop icons
- **Loading state tracking**: Integrated `updateRefreshButton()` calls into tab update and loading state change handlers
- **IPC communication**: 
  - Added `STOP_LOADING` constant to browser IPC events
  - Implemented `stopLoadingTab()` handler in main process that calls `webContents.stop()`
  - Exposed `stopLoadingTab()` method in preload API for renderer access

## Implementation Details
- The refresh button now displays a stop icon (X symbol) when `activeTab.isLoading` is true
- The button updates its appearance whenever the active tab changes or its loading state changes
- Hard reload (Shift+click) functionality is preserved and only triggers when the page is not loading
- The implementation uses Electron's `webContents.stop()` API to halt page loading

https://claude.ai/code/session_017jB8M4PDpbq4ztAFtMR8Mo