### PR TITLE
Add navigation shortcuts and improve keyboard shortcut handling

### DIFF
--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -171,7 +171,7 @@ export abstract class AppMenuManager {
         submenu: [
           {
             label: 'Back',
-            accelerator: 'Alt+Left',
+            accelerator: isMac ? 'Cmd+[' : 'Alt+Left',
             click: () => {
               const activeWindow = AppWindowManager.getActiveWindow();
               if (!activeWindow) return;
@@ -184,7 +184,7 @@ export abstract class AppMenuManager {
           },
           {
             label: 'Forward',
-            accelerator: 'Alt+Right',
+            accelerator: isMac ? 'Cmd+]' : 'Alt+Right',
             click: () => {
               const activeWindow = AppWindowManager.getActiveWindow();
               if (!activeWindow) return;

--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -151,11 +151,11 @@ export abstract class AppMenuManager {
           { type: 'separator' as const },
           {
             label: 'Close Tab',
+            accelerator: 'CmdOrCtrl+W',
             click: async () => {
-              AppWindowManager.getActiveWindow().closeTab(
-                AppWindowManager.getActiveWindow().getActiveTabId(),
-                true
-              );
+              const activeWindow = AppWindowManager.getActiveWindow();
+              if (!activeWindow) return;
+              activeWindow.closeTab(activeWindow.getActiveTabId(), true);
             },
           },
           {
@@ -169,6 +169,33 @@ export abstract class AppMenuManager {
       {
         label: 'Go To',
         submenu: [
+          {
+            label: 'Back',
+            accelerator: 'Alt+Left',
+            click: () => {
+              const activeWindow = AppWindowManager.getActiveWindow();
+              if (!activeWindow) return;
+              const activeTab = activeWindow.getActiveTab();
+              const wc = activeTab?.getWebContentsViewInstance()?.webContents;
+              if (wc?.navigationHistory.canGoBack()) {
+                wc.navigationHistory.goBack();
+              }
+            },
+          },
+          {
+            label: 'Forward',
+            accelerator: 'Alt+Right',
+            click: () => {
+              const activeWindow = AppWindowManager.getActiveWindow();
+              if (!activeWindow) return;
+              const activeTab = activeWindow.getActiveTab();
+              const wc = activeTab?.getWebContentsViewInstance()?.webContents;
+              if (wc?.navigationHistory.canGoForward()) {
+                wc.navigationHistory.goForward();
+              }
+            },
+          },
+          { type: 'separator' as const },
           {
             label: 'Bookmarks',
             accelerator: 'CmdOrCtrl+Shift+B',

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -94,6 +94,15 @@ export class BrowserTabManager {
     this.sslIndicator = document.getElementById('ssl-indicator') as HTMLButtonElement;
 
     this.setupSSLIndicator();
+    this.setupShortcutTooltips();
+  }
+
+  private setupShortcutTooltips(): void {
+    const isMac = window.BrowserAPI.platform === 'darwin';
+    const mod = isMac ? '⌘' : 'Ctrl+';
+    this.backButton.title = `Go back (${isMac ? '⌘[' : 'Alt+Left'})`;
+    this.forwardButton.title = `Go forward (${isMac ? '⌘]' : 'Alt+Right'})`;
+    this.refreshButton.title = `Refresh (${mod}R)`;
   }
 
   private setupEventListeners(): void {

--- a/src/renderer/browser-layout/tab.ts
+++ b/src/renderer/browser-layout/tab.ts
@@ -53,8 +53,10 @@ export class Tab {
     this.tabElement.title = this.title || 'New Tab';
 
     // Add close button event listener
-    const closeButton = this.tabElement.querySelector('#tab-close-button');
+    const closeButton = this.tabElement.querySelector('#tab-close-button') as HTMLElement | null;
     if (closeButton) {
+      const isMac = window.BrowserAPI.platform === 'darwin';
+      closeButton.title = `Close tab (${isMac ? '⌘W' : 'Ctrl+W'})`;
       closeButton.addEventListener('click', (e) => {
         e.stopPropagation();
         window.BrowserAPI.closeTab(appWindowId, this.id, true);

--- a/src/renderer/overlay/panels/command-o/command-o.ts
+++ b/src/renderer/overlay/panels/command-o/command-o.ts
@@ -46,7 +46,7 @@ const COMMAND_O_HTML = `
   <div class="cmdo-overlay-container">
     <!-- Search bar -->
     <div class="search-bar">
-      <span class="shortcut-badge">&#8984;O</span>
+      <span class="shortcut-badge" id="cmdo-shortcut-badge"></span>
       <i data-lucide="search" class="search-icon" width="16" height="16"></i>
       <input type="text" id="cmdo-search-input" class="search-input" placeholder="Search across all tabs..." autofocus>
       <span class="tab-count" id="cmdo-tab-count">0 tabs</span>
@@ -335,6 +335,11 @@ export function init(container: HTMLElement): void {
   tabCountEl = container.querySelector('#cmdo-tab-count') as HTMLElement;
   footerPrivate = container.querySelector('#cmdo-footer-private') as HTMLElement;
   footerDragHint = container.querySelector('#cmdo-footer-drag-hint') as HTMLElement;
+
+  const shortcutBadge = container.querySelector('#cmdo-shortcut-badge') as HTMLElement;
+  if (shortcutBadge) {
+    shortcutBadge.textContent = window.BrowserAPI.platform === 'darwin' ? '⌘O' : 'Ctrl+O';
+  }
 
   if (window.BrowserAPI.isPrivate) {
     footerPrivate.style.display = '';

--- a/src/renderer/overlay/panels/options-menu/options-menu.ts
+++ b/src/renderer/overlay/panels/options-menu/options-menu.ts
@@ -161,13 +161,13 @@ function initializeDomElements(): void {
 
   setShortcut('om-new-tab-shortcut', [modKey, 'T']);
   setShortcut('om-new-window-shortcut', [modKey, 'N']);
-  setShortcut('om-new-private-window-shortcut', [modKey, 'Shift', 'T']);
+  setShortcut('om-new-private-window-shortcut', [modKey, 'Shift', 'N']);
   setShortcut('om-print-shortcut', [modKey, 'P']);
   setShortcut('om-find-in-page-shortcut', [modKey, 'F']);
   setShortcut('om-downloads-shortcut', [modKey, 'Shift', 'D']);
   setShortcut('om-history-shortcut', [modKey, 'Shift', 'H']);
   setShortcut('om-bookmarks-shortcut', [modKey, 'Shift', 'B']);
-  setShortcut('om-browser-settings-shortcut', [modKey, 'Shift', ',']);
+  setShortcut('om-browser-settings-shortcut', [modKey, ',']);
   const devtoolsMod = window.BrowserAPI.platform === 'darwin' ? 'Opt' : 'Shift';
   setShortcut('om-devtools-shortcut', [modKey, devtoolsMod, 'I']);
 

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -981,11 +981,15 @@ function updateProxyFormVisibility(mode: string) {
 }
 
 // ---- Keyboard Shortcuts ----
+function effectiveDefault(s: KeyboardShortcutAction): string {
+  return (isMac && s.defaultShortcutMac) || s.defaultShortcut;
+}
+
 function initKeyboardShortcuts() {
   // Build shortcuts list from defaults + overrides
   shortcuts = DEFAULT_KEYBOARD_SHORTCUTS.map((s) => ({
     ...s,
-    currentShortcut: settings.keyboardShortcuts?.[s.id] || s.defaultShortcut,
+    currentShortcut: settings.keyboardShortcuts?.[s.id] || effectiveDefault(s),
   }));
 
   renderShortcutsTable();
@@ -1010,7 +1014,10 @@ function initKeyboardShortcuts() {
     if (confirm('Reset all keyboard shortcuts to defaults?')) {
       settings.keyboardShortcuts = {};
       saveSettings();
-      shortcuts = DEFAULT_KEYBOARD_SHORTCUTS.map((s) => ({ ...s }));
+      shortcuts = DEFAULT_KEYBOARD_SHORTCUTS.map((s) => ({
+        ...s,
+        currentShortcut: effectiveDefault(s),
+      }));
       renderShortcutsTable();
       showToast('All shortcuts reset to defaults');
     }
@@ -1045,7 +1052,7 @@ function renderShortcutsTable() {
     tr.innerHTML = `
       <td>${shortcut.label}</td>
       <td><span class="shortcut-category-badge">${shortcut.category}</span></td>
-      <td>${formatShortcutDisplay(shortcut.defaultShortcut)}</td>
+      <td>${formatShortcutDisplay(effectiveDefault(shortcut))}</td>
       <td class="shortcut-key-cell" data-action-id="${shortcut.id}">
         <span class="shortcut-key">${formatShortcutDisplay(shortcut.currentShortcut)}</span>
       </td>
@@ -1062,7 +1069,7 @@ function renderShortcutsTable() {
     const resetBtn = tr.querySelector('.shortcut-reset-btn') as HTMLElement;
     resetBtn?.addEventListener('click', (e) => {
       e.stopPropagation();
-      shortcut.currentShortcut = shortcut.defaultShortcut;
+      shortcut.currentShortcut = effectiveDefault(shortcut);
       if (settings.keyboardShortcuts?.[shortcut.id]) {
         delete settings.keyboardShortcuts[shortcut.id];
       }

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -278,6 +278,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     label: 'Back',
     category: 'Navigation',
     defaultShortcut: 'Alt+Left',
+    defaultShortcutMac: 'mod+[',
     currentShortcut: 'Alt+Left',
   },
   {
@@ -285,6 +286,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     label: 'Forward',
     category: 'Navigation',
     defaultShortcut: 'Alt+Right',
+    defaultShortcutMac: 'mod+]',
     currentShortcut: 'Alt+Right',
   },
   {

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -23,6 +23,7 @@ export interface KeyboardShortcutAction {
   label: string;
   category: string;
   defaultShortcut: string;
+  defaultShortcutMac?: string;
   currentShortcut: string;
   isReserved?: boolean;
 }
@@ -259,13 +260,6 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     currentShortcut: 'mod+Shift+N',
   },
   {
-    id: 'focus-url-bar',
-    label: 'Focus URL Bar',
-    category: 'Navigation',
-    defaultShortcut: 'mod+L',
-    currentShortcut: 'mod+L',
-  },
-  {
     id: 'reload-page',
     label: 'Reload Page',
     category: 'Navigation',
@@ -322,13 +316,6 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     currentShortcut: 'mod+Shift+H',
   },
   {
-    id: 'bookmark-page',
-    label: 'Bookmark Page',
-    category: 'Bookmarks',
-    defaultShortcut: 'mod+D',
-    currentShortcut: 'mod+D',
-  },
-  {
     id: 'open-bookmarks',
     label: 'Open Bookmarks',
     category: 'Bookmarks',
@@ -340,6 +327,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     label: 'Toggle DevTools',
     category: 'Developer',
     defaultShortcut: 'mod+Shift+I',
+    defaultShortcutMac: 'mod+Alt+I',
     currentShortcut: 'mod+Shift+I',
   },
   {
@@ -369,6 +357,13 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     category: 'Utilities',
     defaultShortcut: 'mod+K',
     currentShortcut: 'mod+K',
+  },
+  {
+    id: 'tab-switcher',
+    label: 'Tab Switcher',
+    category: 'Tabs',
+    defaultShortcut: 'mod+O',
+    currentShortcut: 'mod+O',
   },
 ];
 


### PR DESCRIPTION
## Summary
This PR enhances the browser's navigation capabilities and improves keyboard shortcut management with platform-specific support.

## Key Changes

- **Navigation Menu Items**: Added "Back" (Alt+Left) and "Forward" (Alt+Right) menu items to the "Go To" submenu with proper null-safety checks
- **Close Tab Shortcut**: Added keyboard accelerator (CmdOrCtrl+W) to the "Close Tab" menu item and improved null-safety
- **Platform-Specific Shortcuts**: Introduced `defaultShortcutMac` field to `KeyboardShortcutAction` interface to support macOS-specific keyboard shortcuts
- **DevTools Shortcut**: Added macOS-specific shortcut (Cmd+Alt+I) for Toggle DevTools, while keeping Ctrl+Shift+I as default for other platforms
- **Removed Shortcuts**: Cleaned up unused keyboard shortcuts ("Focus URL Bar" and "Bookmark Page") from the defaults list
- **New Shortcut**: Added "Tab Switcher" (Mod+O) to the keyboard shortcuts list
- **Shortcut Display Logic**: Implemented `effectiveDefault()` helper function to determine the correct default shortcut based on platform, ensuring macOS users see appropriate shortcuts in the settings UI

## Implementation Details

- The `effectiveDefault()` function checks if a macOS-specific default exists and uses it; otherwise falls back to the standard default
- All navigation menu click handlers include null-safety checks for `activeWindow` and `activeTab`
- The shortcut reset functionality now properly applies platform-specific defaults
- Settings UI now displays the correct default shortcut for the user's platform

https://claude.ai/code/session_018FH59VvC9oSPXbw6fBR9rr