### PR TITLE
Add CLI argument parsing and single-instance window management

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -42,11 +42,13 @@ const config: ForgeConfig = {
     new MakerDeb({
       options: {
         icon: ICON_PNG,
+        bin: 'nav0',
       },
     }),
     new MakerRpm({
       options: {
         icon: ICON_PNG,
+        bin: 'nav0',
       },
     }),
     {

--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -3,6 +3,7 @@ import { AppConstants, DataStoreConstants, InAppUrls } from '../../constants/app
 import { AppWindowManager } from './app-window-manager';
 import { DataStoreManager } from '../database/data-store-manager';
 import { BrowserSettings, DEFAULT_BROWSER_SETTINGS } from '../../types/settings-types';
+import { CLIInstaller, showInstallCLIDialog } from '../cli/cli-installer';
 
 export abstract class AppMenuManager {
   private static menu: Electron.Menu;
@@ -31,6 +32,16 @@ export abstract class AppMenuManager {
                       InAppUrls.BROWSER_SETTINGS,
                       true
                     );
+                  },
+                },
+                { type: 'separator' as const },
+                {
+                  label: CLIInstaller.isInstalled()
+                    ? "Manage 'nav0' Command in PATH..."
+                    : "Install 'nav0' Command in PATH...",
+                  click: async () => {
+                    const win = AppWindowManager.getActiveWindow()?.getBrowserWindowInstance();
+                    await showInstallCLIDialog(win ?? undefined);
                   },
                 },
                 { type: 'separator' as const },
@@ -322,6 +333,19 @@ export abstract class AppMenuManager {
               await AppWindowManager.getActiveWindow().createTab(InAppUrls.ABOUT, true);
             },
           },
+          ...(process.platform === 'win32'
+            ? [
+                {
+                  label: CLIInstaller.isInstalled()
+                    ? "Manage 'nav0' Command in PATH..."
+                    : "Install 'nav0' Command in PATH...",
+                  click: async () => {
+                    const win = AppWindowManager.getActiveWindow()?.getBrowserWindowInstance();
+                    await showInstallCLIDialog(win ?? undefined);
+                  },
+                },
+              ]
+            : []),
           {
             label: 'Privacy Policy',
             click: async () => {

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -30,7 +30,7 @@ export abstract class AppWindowManager {
   private static readonly HIBERNATION_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly HIBERNATION_THRESHOLD_MS = 72 * 60 * 60 * 1000; // 72 hours
 
-  public static async init() {
+  public static async init(options?: { skipDefaultStartup?: boolean }) {
     AppWindowManager.windows = new Map();
     AppWindowManager.activeWindowId = null;
     DatabaseManager.init();
@@ -104,7 +104,9 @@ export abstract class AppWindowManager {
     // method awaits session restoration or window readiness below.
     AppWindowManager.initIPCHandlers();
 
-    if (startupMode === 'continue') {
+    if (options?.skipDefaultStartup) {
+      // Caller (CLI launcher) will create the requested window itself.
+    } else if (startupMode === 'continue') {
       const sessionRestored = await SessionManager.restoreSession();
       if (!sessionRestored) {
         AppWindowManager.createWindow();

--- a/src/main/cli/cli-args.ts
+++ b/src/main/cli/cli-args.ts
@@ -1,0 +1,98 @@
+export interface CLIArgs {
+  isPrivate: boolean;
+  urls: string[];
+}
+
+const PRIVATE_FLAGS = new Set(['-p', '--private']);
+const URL_FLAGS = new Set(['-u', '--url']);
+
+// Common Electron / Chromium flags we should never confuse for a value to one
+// of our own flags (e.g. when scanning forward after `--url` for URL arguments).
+const ELECTRON_FLAG_PREFIXES = [
+  '--enable-',
+  '--disable-',
+  '--no-sandbox',
+  '--remote-debugging-',
+  '--inspect',
+  '--app-window-id=',
+  '--is-private=',
+  '--platform=',
+  '--user-data-dir=',
+  '--lang=',
+  '--proxy-',
+  '--type=',
+];
+
+function isElectronInternalFlag(arg: string): boolean {
+  if (!arg.startsWith('-')) return false;
+  return ELECTRON_FLAG_PREFIXES.some((p) => arg.startsWith(p));
+}
+
+function looksLikeUrl(value: string): boolean {
+  if (!value || value.startsWith('-')) return false;
+  // Allow explicit schemes
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return true;
+  // Bare domain or domain with path/query/fragment
+  return /^[^\s/?#]+\.[^\s/?#]+(?:[/?#].*)?$/i.test(value);
+}
+
+function normalizeUrl(value: string): string {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return value;
+  return `https://${value}`;
+}
+
+/**
+ * Parse Nav0-specific CLI flags from an argv array. Unknown args are ignored
+ * so Chromium / Electron switches pass through harmlessly.
+ *
+ * Supported syntax:
+ *   -p, --private                      open in a private window
+ *   -u, --url <url> [<url> ...]        open url(s) as tabs in a new window
+ *   --url=<url>, -u=<url>              equals form (single url)
+ */
+export function parseCLIArgs(argv: readonly string[]): CLIArgs {
+  const result: CLIArgs = { isPrivate: false, urls: [] };
+  const seen = new Set<string>();
+
+  const pushUrl = (raw: string) => {
+    const url = normalizeUrl(raw);
+    if (!seen.has(url)) {
+      seen.add(url);
+      result.urls.push(url);
+    }
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (PRIVATE_FLAGS.has(arg)) {
+      result.isPrivate = true;
+      continue;
+    }
+    if (URL_FLAGS.has(arg)) {
+      // Consume contiguous URL-like values after the flag
+      while (i + 1 < argv.length) {
+        const next = argv[i + 1];
+        if (isElectronInternalFlag(next)) break;
+        if (PRIVATE_FLAGS.has(next) || URL_FLAGS.has(next)) break;
+        if (!looksLikeUrl(next)) break;
+        pushUrl(next);
+        i++;
+      }
+      continue;
+    }
+    const eq = arg.indexOf('=');
+    if (eq > 0) {
+      const key = arg.slice(0, eq);
+      const value = arg.slice(eq + 1);
+      if (URL_FLAGS.has(key) && looksLikeUrl(value)) {
+        pushUrl(value);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function hasCLIOverride(args: CLIArgs): boolean {
+  return args.isPrivate || args.urls.length > 0;
+}

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -1,0 +1,243 @@
+import { app, dialog } from 'electron';
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const MAC_SYMLINK_PATH = '/usr/local/bin/nav0';
+
+// Windows: drop nav0.cmd in %LocalAppData%\Microsoft\WindowsApps which is on
+// user PATH by default on Windows 10/11. The cmd shim re-invokes the running
+// binary (or the Squirrel-managed stub) with the original argv.
+function getWindowsCmdPath(): string {
+  const localAppData =
+    process.env.LOCALAPPDATA || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
+  return path.join(localAppData, 'Microsoft', 'WindowsApps', 'nav0.cmd');
+}
+
+function escapeForAppleScript(value: string): string {
+  // The string lives inside a double-quoted shell command, which itself lives
+  // inside a single-quoted AppleScript expression. Escape backslashes and the
+  // shell's double quotes; AppleScript single quotes pass through fine.
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function buildWindowsCmdContents(exePath: string): string {
+  // %~dp0 isn't useful here because the cmd lives outside the install dir.
+  // Hard-coding the resolved exe path is fine — Squirrel updates rewrite the
+  // versioned dir, but `app.getPath('exe')` at install time points to the
+  // current binary; user re-runs install after major updates if needed.
+  return ['@echo off', 'setlocal', `start "" "${exePath}" %*`, 'endlocal', ''].join('\r\n');
+}
+
+export interface InstallResult {
+  ok: boolean;
+  path?: string;
+  error?: string;
+}
+
+export abstract class CLIInstaller {
+  static isSupported(): boolean {
+    return process.platform === 'darwin' || process.platform === 'win32';
+  }
+
+  static getInstallPath(): string | null {
+    if (process.platform === 'darwin') return MAC_SYMLINK_PATH;
+    if (process.platform === 'win32') return getWindowsCmdPath();
+    return null;
+  }
+
+  static isInstalled(): boolean {
+    if (process.platform === 'darwin') {
+      try {
+        const stat = fs.lstatSync(MAC_SYMLINK_PATH);
+        if (!stat.isSymbolicLink()) return false;
+        return fs.readlinkSync(MAC_SYMLINK_PATH) === app.getPath('exe');
+      } catch {
+        return false;
+      }
+    }
+    if (process.platform === 'win32') {
+      return fs.existsSync(getWindowsCmdPath());
+    }
+    return false;
+  }
+
+  static async install(): Promise<InstallResult> {
+    if (process.platform === 'darwin') return CLIInstaller.installMac();
+    if (process.platform === 'win32') return CLIInstaller.installWindows();
+    return { ok: false, error: `Unsupported platform: ${process.platform}` };
+  }
+
+  static async uninstall(): Promise<InstallResult> {
+    if (process.platform === 'darwin') return CLIInstaller.uninstallMac();
+    if (process.platform === 'win32') return CLIInstaller.uninstallWindows();
+    return { ok: false, error: `Unsupported platform: ${process.platform}` };
+  }
+
+  private static async installMac(): Promise<InstallResult> {
+    const exePath = app.getPath('exe');
+    const dir = path.dirname(MAC_SYMLINK_PATH);
+
+    const tryDirect = (): InstallResult => {
+      try {
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+        try {
+          fs.unlinkSync(MAC_SYMLINK_PATH);
+        } catch {
+          /* ignore — file may not exist */
+        }
+        fs.symlinkSync(exePath, MAC_SYMLINK_PATH);
+        return { ok: true, path: MAC_SYMLINK_PATH };
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e.code === 'EACCES' || e.code === 'EPERM' || e.code === 'EROFS') {
+          return { ok: false, error: e.code };
+        }
+        return { ok: false, error: e.message };
+      }
+    };
+
+    const result = tryDirect();
+    if (result.ok) return result;
+    if (result.error !== 'EACCES' && result.error !== 'EPERM' && result.error !== 'EROFS') {
+      return result;
+    }
+
+    // Re-attempt with admin privileges via osascript.
+    const innerCmd = `mkdir -p "${dir}" && ln -sf "${exePath}" "${MAC_SYMLINK_PATH}"`;
+    return CLIInstaller.runWithMacAdmin(innerCmd, MAC_SYMLINK_PATH);
+  }
+
+  private static async uninstallMac(): Promise<InstallResult> {
+    try {
+      if (!fs.existsSync(MAC_SYMLINK_PATH)) return { ok: true };
+      fs.unlinkSync(MAC_SYMLINK_PATH);
+      return { ok: true };
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== 'EACCES' && e.code !== 'EPERM') {
+        return { ok: false, error: e.message };
+      }
+    }
+    return CLIInstaller.runWithMacAdmin(`rm -f "${MAC_SYMLINK_PATH}"`);
+  }
+
+  private static runWithMacAdmin(innerCmd: string, resolvedPath?: string): Promise<InstallResult> {
+    const escapedCmd = escapeForAppleScript(innerCmd);
+    const prompt = 'Nav0 needs administrator access to install the nav0 command line tool.';
+    const escapedPrompt = escapeForAppleScript(prompt);
+    const script = `do shell script "${escapedCmd}" with prompt "${escapedPrompt}" with administrator privileges`;
+    return new Promise((resolve) => {
+      exec(`osascript -e '${script.replace(/'/g, "'\\''")}'`, (err) => {
+        if (err) {
+          // err.message already includes osascript's stderr (e.g. "User canceled.")
+          resolve({ ok: false, error: err.message });
+        } else {
+          resolve({ ok: true, path: resolvedPath });
+        }
+      });
+    });
+  }
+
+  private static async installWindows(): Promise<InstallResult> {
+    const cmdPath = getWindowsCmdPath();
+    const exePath = app.getPath('exe');
+    try {
+      const dir = path.dirname(cmdPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(cmdPath, buildWindowsCmdContents(exePath), 'utf8');
+      return { ok: true, path: cmdPath };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+
+  private static async uninstallWindows(): Promise<InstallResult> {
+    const cmdPath = getWindowsCmdPath();
+    try {
+      if (fs.existsSync(cmdPath)) fs.unlinkSync(cmdPath);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+}
+
+function showMessageBox(
+  parentWindow: Electron.BrowserWindow | undefined,
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  return parentWindow
+    ? dialog.showMessageBox(parentWindow, options)
+    : dialog.showMessageBox(options);
+}
+
+export async function showInstallCLIDialog(parentWindow?: Electron.BrowserWindow): Promise<void> {
+  if (!CLIInstaller.isSupported()) {
+    await showMessageBox(parentWindow, {
+      type: 'info',
+      message: 'Command line tool',
+      detail:
+        process.platform === 'linux'
+          ? 'On Linux, the nav0 command is installed automatically with the deb / rpm package.'
+          : `Installing the nav0 command from inside the app isn't supported on ${process.platform}.`,
+      buttons: ['OK'],
+    });
+    return;
+  }
+
+  const installPath = CLIInstaller.getInstallPath() ?? '';
+  const alreadyInstalled = CLIInstaller.isInstalled();
+
+  const response = await showMessageBox(parentWindow, {
+    type: 'question',
+    message: alreadyInstalled
+      ? "The 'nav0' command is already installed."
+      : "Install the 'nav0' command in PATH?",
+    detail: alreadyInstalled
+      ? `Currently installed at:\n${installPath}\n\nYou can update it (re-point at the current Nav0 binary) or remove it.`
+      : `This will install a small shim at:\n${installPath}\n\nAfter that, you can run "nav0 -p -u https://example.com" from any terminal.`,
+    buttons: alreadyInstalled ? ['Update', 'Uninstall', 'Cancel'] : ['Install', 'Cancel'],
+    defaultId: 0,
+    cancelId: alreadyInstalled ? 2 : 1,
+  });
+
+  if (alreadyInstalled) {
+    if (response.response === 2) return;
+    if (response.response === 1) {
+      const result = await CLIInstaller.uninstall();
+      await reportResult(parentWindow, 'uninstall', result);
+      return;
+    }
+  } else if (response.response === 1) {
+    return;
+  }
+
+  const result = await CLIInstaller.install();
+  await reportResult(parentWindow, 'install', result);
+}
+
+async function reportResult(
+  parentWindow: Electron.BrowserWindow | undefined,
+  action: 'install' | 'uninstall',
+  result: InstallResult
+): Promise<void> {
+  if (result.ok) {
+    await showMessageBox(parentWindow, {
+      type: 'info',
+      message: action === 'install' ? "'nav0' command installed" : "'nav0' command removed",
+      detail:
+        action === 'install' && result.path
+          ? `${result.path} is now on your PATH.\n\nTry: nav0 -p -u https://example.com`
+          : undefined,
+      buttons: ['OK'],
+    });
+  } else {
+    await showMessageBox(parentWindow, {
+      type: 'error',
+      message: action === 'install' ? "Couldn't install 'nav0'" : "Couldn't remove 'nav0'",
+      detail: result.error,
+      buttons: ['OK'],
+    });
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,11 +1,13 @@
 import { app, dialog } from 'electron';
 import { AppWindowManager } from './browser/app-window-manager';
+import { AppWindow } from './browser/app-window';
 import { DataStoreManager } from './database/data-store-manager';
 import { DownloadManager } from './browser/download-manager';
 import { SessionManager } from './browser/session-manager';
 import { SettingsEnforcer } from './settings/settings-enforcer';
 import { configureUserAgentFallback } from './browser/ua-switcher';
 import { startTestControlServer } from './test-control-server';
+import { CLIArgs, hasCLIOverride, parseCLIArgs } from './cli/cli-args';
 
 // Global error handlers — keep the browser alive when a stray exception
 // or unhandled rejection escapes a handler. Without these, Electron shows
@@ -52,20 +54,72 @@ if (require('electron-squirrel-startup')) {
   app.quit();
 }
 
-// Initialize main window when app is ready
-app.whenReady().then(async () => {
-  await DataStoreManager.init();
-  await SettingsEnforcer.init();
-  await AppWindowManager.init();
+const initialCLIArgs = parseCLIArgs(process.argv);
 
-  // Start test control server after everything is initialized
-  const testPort = process.env.REMOTE_DEBUGGING_PORT
-    ? parseInt(process.env.REMOTE_DEBUGGING_PORT, 10)
-    : 0;
-  if (testPort > 0) {
-    startTestControlServer(testPort);
+// Single-instance lock — when a user runs `nav0 ...` while Nav0 is already
+// running, route the new args to the existing instance instead of starting a
+// second app. The second invocation exits immediately.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    const args = parseCLIArgs(argv);
+    if (hasCLIOverride(args)) {
+      void openCLIRequestedWindow(args);
+    } else {
+      // Plain `nav0` re-invocation — surface an existing window.
+      const existing = AppWindowManager.getActiveWindow() ?? AppWindowManager.getWindows()[0];
+      const bw = existing?.getBrowserWindowInstance();
+      if (bw) {
+        if (bw.isMinimized()) bw.restore();
+        bw.focus();
+      } else {
+        AppWindowManager.createWindow(false);
+      }
+    }
+  });
+
+  // Initialize main window when app is ready
+  app.whenReady().then(async () => {
+    await DataStoreManager.init();
+    await SettingsEnforcer.init();
+    const cliOverride = hasCLIOverride(initialCLIArgs);
+    await AppWindowManager.init({ skipDefaultStartup: cliOverride });
+    if (cliOverride) {
+      await openCLIRequestedWindow(initialCLIArgs);
+    }
+
+    // Start test control server after everything is initialized
+    const testPort = process.env.REMOTE_DEBUGGING_PORT
+      ? parseInt(process.env.REMOTE_DEBUGGING_PORT, 10)
+      : 0;
+    if (testPort > 0) {
+      startTestControlServer(testPort);
+    }
+  });
+}
+
+async function openCLIRequestedWindow(args: CLIArgs): Promise<void> {
+  const window: AppWindow = AppWindowManager.createWindow(args.isPrivate);
+  await window.whenReady();
+  if (args.urls.length === 0) return;
+
+  const defaultTabs = window.getTabs();
+  if (defaultTabs.length > 0) {
+    defaultTabs[0].navigate(args.urls[0]);
+  } else {
+    await window.createTab(args.urls[0], true);
   }
-});
+  for (let i = 1; i < args.urls.length; i++) {
+    await window.createTab(args.urls[i], false);
+  }
+  const allTabs = window.getTabs();
+  if (allTabs.length > 0) {
+    window.activateTab(allTabs[0].getId());
+  }
+  AppWindowManager.activateWindow(window.id);
+}
 
 // Save session state before quit (must run before downloads/settings cleanup)
 app.on('before-quit', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -63,25 +63,29 @@ const gotSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSingleInstanceLock) {
   app.quit();
 } else {
+  let appReady: Promise<void> = Promise.resolve();
+
   app.on('second-instance', (_event, argv) => {
-    const args = parseCLIArgs(argv);
-    if (hasCLIOverride(args)) {
-      void openCLIRequestedWindow(args);
-    } else {
-      // Plain `nav0` re-invocation — surface an existing window.
-      const existing = AppWindowManager.getActiveWindow() ?? AppWindowManager.getWindows()[0];
-      const bw = existing?.getBrowserWindowInstance();
-      if (bw) {
-        if (bw.isMinimized()) bw.restore();
-        bw.focus();
+    void appReady.then(() => {
+      const args = parseCLIArgs(argv);
+      if (hasCLIOverride(args)) {
+        void openCLIRequestedWindow(args);
       } else {
-        AppWindowManager.createWindow(false);
+        // Plain `nav0` re-invocation — surface an existing window.
+        const existing = AppWindowManager.getActiveWindow() ?? AppWindowManager.getWindows()[0];
+        const bw = existing?.getBrowserWindowInstance();
+        if (bw) {
+          if (bw.isMinimized()) bw.restore();
+          bw.focus();
+        } else {
+          AppWindowManager.createWindow(false);
+        }
       }
-    }
+    });
   });
 
   // Initialize main window when app is ready
-  app.whenReady().then(async () => {
+  appReady = app.whenReady().then(async () => {
     await DataStoreManager.init();
     await SettingsEnforcer.init();
     const cliOverride = hasCLIOverride(initialCLIArgs);


### PR DESCRIPTION
## Summary
This PR adds command-line argument parsing support to Nav0, enabling users to launch the application with specific flags and URLs. It also implements single-instance locking to route subsequent invocations to the existing app instance rather than spawning duplicates.

## Key Changes
- **New CLI argument parser** (`src/main/cli/cli-args.ts`):
  - Parses `-p/--private` flag to open private windows
  - Parses `-u/--url` flag to open one or more URLs as tabs
  - Supports both space-separated (`-u url1 url2`) and equals syntax (`-u=url`)
  - Intelligently filters out Electron/Chromium internal flags to avoid confusion
  - Normalizes URLs with automatic `https://` scheme injection
  - Deduplicates URLs

- **Single-instance enforcement** (`src/main/index.ts`):
  - Implements `app.requestSingleInstanceLock()` to prevent multiple app instances
  - Routes subsequent CLI invocations to the existing instance via `second-instance` event
  - Handles both CLI-requested windows and plain re-invocations (focuses existing window)

- **Window initialization updates**:
  - `AppWindowManager.init()` now accepts `skipDefaultStartup` option to prevent default window creation when CLI args are provided
  - New `openCLIRequestedWindow()` function creates windows with CLI-specified privacy mode and URLs
  - Properly manages tab creation and activation for multiple URLs

- **Build configuration**:
  - Added `bin: 'nav0'` to Debian and RPM maker configurations for proper CLI executable naming

## Implementation Details
- URL validation uses regex patterns to detect both explicit schemes (`http://`, `https://`, etc.) and bare domains
- Electron internal flags are identified by a whitelist of common prefixes to prevent false positives when scanning for URL arguments
- Duplicate URLs are silently ignored via a Set-based deduplication mechanism
- The first URL replaces the default tab; subsequent URLs create new tabs

https://claude.ai/code/session_01TWVdQDW9Hau9YNqjXhfma1