### PR TITLE
Add reporter contact field and build mode to issue reports

### DIFF
--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -931,6 +931,7 @@ export abstract class AppWindowManager {
 
       return {
         appVersion: app.getVersion(),
+        isPackaged: app.isPackaged,
         electronVersion: process.versions.electron,
         chromiumVersion: process.versions.chrome,
         nodeVersion: process.versions.node,

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -125,6 +125,7 @@ declare global {
       ) => Promise<{ success: boolean }>;
       getAboutInfo: () => Promise<{
         appVersion: string;
+        isPackaged: boolean;
         electronVersion: string;
         chromiumVersion: string;
         nodeVersion: string;

--- a/src/renderer/overlay/panels/issue-report/issue-report.css
+++ b/src/renderer/overlay/panels/issue-report/issue-report.css
@@ -96,6 +96,12 @@
   color: var(--text-color);
 }
 
+.issue-report-body .form-label-optional {
+  font-weight: 400;
+  color: var(--text-secondary);
+  font-size: var(--font-xs);
+}
+
 .issue-report-body .form-control {
   display: block;
   width: 100%;

--- a/src/renderer/overlay/panels/issue-report/issue-report.ts
+++ b/src/renderer/overlay/panels/issue-report/issue-report.ts
@@ -49,6 +49,11 @@ const ISSUE_REPORT_HTML = `
         </div>
 
         <div class="form-group">
+          <label class="form-label" for="ir-issue-reported-by">Reported By <span class="form-label-optional">(optional)</span></label>
+          <input type="text" class="form-control" id="ir-issue-reported-by" placeholder="Your name, email, or GitHub handle" maxlength="200" />
+        </div>
+
+        <div class="form-group">
           <label class="form-label">Attachments</label>
           <div class="attachment-area" id="ir-attachment-area">
             <label class="attachment-drop-zone" id="ir-attachment-drop-zone" for="ir-attachment-input">
@@ -79,10 +84,14 @@ const ISSUE_REPORT_HTML = `
 
 async function getSystemInfo(): Promise<string> {
   const platform = window.BrowserAPI?.platform || navigator.platform;
+  let appVersion = 'unknown';
+  let buildMode = 'unknown';
   let electronVersion = 'unknown';
   let chromeVersion = 'unknown';
   try {
     const info = await window.BrowserAPI.getAboutInfo();
+    appVersion = info.appVersion || 'unknown';
+    buildMode = info.isPackaged ? 'Installed' : 'Development';
     electronVersion = info.electronVersion || 'unknown';
     chromeVersion = info.chromiumVersion || 'unknown';
   } catch {
@@ -93,6 +102,8 @@ async function getSystemInfo(): Promise<string> {
     chromeVersion = chromeMatch ? chromeMatch[1] : 'unknown';
   }
   const lines = [
+    `Nav0 Version: ${appVersion}`,
+    `Build Mode: ${buildMode}`,
     `Platform: ${platform}`,
     `Electron: ${electronVersion}`,
     `Chrome: ${chromeVersion}`,
@@ -280,11 +291,15 @@ function resetForm(): void {
   const titleInput = containerEl.querySelector('#ir-issue-title') as HTMLInputElement;
   const descInput = containerEl.querySelector('#ir-issue-description') as HTMLTextAreaElement;
   const typeSelect = containerEl.querySelector('#ir-issue-type') as HTMLSelectElement;
+  const reportedByInput = containerEl.querySelector(
+    '#ir-issue-reported-by'
+  ) as HTMLInputElement;
   const statusEl = containerEl.querySelector('#ir-issue-report-status') as HTMLElement;
 
   if (titleInput) titleInput.value = '';
   if (descInput) descInput.value = '';
   if (typeSelect) typeSelect.value = 'bug';
+  if (reportedByInput) reportedByInput.value = '';
   if (statusEl) statusEl.style.display = 'none';
 
   // Clear attachments
@@ -299,11 +314,15 @@ async function submitIssue(): Promise<void> {
     '#ir-issue-description'
   ) as HTMLTextAreaElement;
   const typeSelect = containerEl.querySelector('#ir-issue-type') as HTMLSelectElement;
+  const reportedByInput = containerEl.querySelector(
+    '#ir-issue-reported-by'
+  ) as HTMLInputElement;
   const submitBtn = containerEl.querySelector('#ir-issue-submit-btn') as HTMLButtonElement;
 
   const title = titleInput.value.trim();
   const description = descriptionInput.value.trim();
   const type = typeSelect.value;
+  const reportedBy = reportedByInput?.value.trim() || '';
 
   if (!title) {
     showStatus('Please enter a title.', 'error');
@@ -330,7 +349,8 @@ async function submitIssue(): Promise<void> {
   }));
 
   const sysInfo = await getSystemInfo();
-  const body = `**Type:** ${typeLabel}\n\n**Description:**\n${description}\n\n---\n**System Info:**\n\`\`\`\n${sysInfo}\n\`\`\`\n\n*Submitted from Nav0 Browser in-app issue reporter*`;
+  const reportedBySection = reportedBy ? `**Reported By:** ${reportedBy}\n\n` : '';
+  const body = `**Type:** ${typeLabel}\n\n${reportedBySection}**Description:**\n${description}\n\n---\n**System Info:**\n\`\`\`\n${sysInfo}\n\`\`\`\n\n*Submitted from Nav0 Browser in-app issue reporter*`;
 
   try {
     const response = await fetch(WORKER_URL, {


### PR DESCRIPTION
## Summary
Enhanced the issue report form to collect optional reporter contact information and improved system information reporting by including the app version and build mode.

## Key Changes
- **New "Reported By" field**: Added an optional text input field to the issue report form where users can provide their name, email, or GitHub handle (max 200 characters)
- **Enhanced system info**: Extended `getSystemInfo()` to include:
  - App version from `BrowserAPI.getAboutInfo()`
  - Build mode (displays "Installed" for packaged builds or "Development" for development builds)
- **Updated issue body template**: Modified the GitHub issue body to include the reporter contact information when provided
- **Form reset handling**: Updated `resetForm()` to clear the new "Reported By" field
- **API updates**: Added `isPackaged` property to the `getAboutInfo()` response in both the main process and renderer API declarations
- **Styling**: Added CSS styling for optional field labels with secondary text color and smaller font size

## Implementation Details
- The "Reported By" field is optional and only included in the issue body if a value is provided
- The build mode is determined using Electron's `app.isPackaged` property
- All form field references are properly type-cast and null-checked before use

https://claude.ai/code/session_01E6Htk6yqzVMSMxoKRWnjRb