### PR TITLE
Set platform-specific executable names in Electron Forge config

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -20,6 +20,7 @@ const ICON_ICO = path.resolve(__dirname, 'src/renderer/assets/favicon.ico');
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    executableName: process.platform === 'linux' ? 'nav0' : 'Nav0',
     icon: ICON_BASE,
     extraResource: [],
     extendInfo: {


### PR DESCRIPTION
## Summary
Updated the Electron Forge packager configuration to use platform-specific executable names for the built application.

## Key Changes
- Added `executableName` configuration to `packagerConfig` in `forge.config.ts`
- Linux builds will use lowercase `nav0` as the executable name
- macOS and Windows builds will use `Nav0` (capitalized) as the executable name

## Implementation Details
The executable name is determined at build time using `process.platform` to detect the target operating system. This ensures the application follows platform-specific naming conventions (lowercase for Linux, capitalized for other platforms).

https://claude.ai/code/session_011GCGJq5GXyNmyfiud3tcwi