### PR TITLE
Isolate dev builds and fix cookie encryption on macOS

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -175,7 +175,7 @@ const config: ForgeConfig = {
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
-      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableCookieEncryption]: false,
       [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
       [FuseV1Options.EnableNodeCliInspectArguments]: false,
       [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -175,7 +175,12 @@ const config: ForgeConfig = {
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
-      [FuseV1Options.EnableCookieEncryption]: false,
+      // Disabled on macOS: without an Apple Developer ID, OSCrypt can't
+      // reliably persist its key in the Keychain, so cookies become
+      // unreadable on the next launch and users get logged out. Windows
+      // (DPAPI) and Linux (libsecret) don't need a signed binary, so we
+      // keep encryption on there.
+      [FuseV1Options.EnableCookieEncryption]: process.platform !== 'darwin',
       [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
       [FuseV1Options.EnableNodeCliInspectArguments]: false,
       [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { app, dialog } from 'electron';
 import { AppWindowManager } from './browser/app-window-manager';
 import { DataStoreManager } from './database/data-store-manager';
@@ -38,6 +39,18 @@ process.on('unhandledRejection', (reason: unknown) => {
 // Cloudflare Turnstile) don't flag webContents we haven't explicitly configured.
 // Must run before any BrowserWindow / WebContentsView is created.
 configureUserAgentFallback();
+
+// Isolate dev from the installed Nav0 and avoid the macOS Keychain dependency.
+// The dev binary runs from node_modules/electron (CFBundleName "Electron"),
+// so it would otherwise share userData with the installed app but try to
+// derive its OSCrypt key from a different keychain entry — and on unsigned
+// dev builds that entry often can't be created at all, leaving Chromium with
+// a per-process random key and cookies that vanish on the next launch.
+// Production keeps real OSCrypt via the EnableCookieEncryption fuse.
+if (!app.isPackaged) {
+  app.setPath('userData', path.join(app.getPath('appData'), 'Nav0 (Dev)'));
+  app.commandLine.appendSwitch('use-mock-keychain');
+}
 
 // Disable Chromium features that trigger macOS "Local Network" permission dialog.
 // These features use mDNS/Bonjour for device discovery, which is unnecessary for

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,16 +40,11 @@ process.on('unhandledRejection', (reason: unknown) => {
 // Must run before any BrowserWindow / WebContentsView is created.
 configureUserAgentFallback();
 
-// Isolate dev from the installed Nav0 and avoid the macOS Keychain dependency.
-// The dev binary runs from node_modules/electron (CFBundleName "Electron"),
-// so it would otherwise share userData with the installed app but try to
-// derive its OSCrypt key from a different keychain entry — and on unsigned
-// dev builds that entry often can't be created at all, leaving Chromium with
-// a per-process random key and cookies that vanish on the next launch.
-// Production keeps real OSCrypt via the EnableCookieEncryption fuse.
+// Isolate dev from the installed Nav0 so the two don't share the same userData
+// directory (cookie store, history DB, settings). Lets you run both side-by-side
+// and keeps experimental dev runs from clobbering the installed app's state.
 if (!app.isPackaged) {
   app.setPath('userData', path.join(app.getPath('appData'), 'Nav0 (Dev)'));
-  app.commandLine.appendSwitch('use-mock-keychain');
 }
 
 // Disable Chromium features that trigger macOS "Local Network" permission dialog.


### PR DESCRIPTION
## Summary
This PR improves the development experience and fixes a critical issue with cookie persistence on macOS by isolating development builds from installed versions and conditionally disabling cookie encryption on platforms where it causes problems.

## Key Changes
- **Isolate dev builds**: Development builds now use a separate `userData` directory (`Nav0 (Dev)`) to prevent sharing state (cookies, history, settings) with installed versions. This allows running dev and production builds side-by-side without interference.
- **Fix macOS cookie encryption**: Disabled cookie encryption on macOS where it causes issues. Without an Apple Developer ID, OSCrypt cannot reliably persist its encryption key in the Keychain, resulting in unreadable cookies on subsequent launches and users being logged out. Windows (DPAPI) and Linux (libsecret) don't require a signed binary, so encryption remains enabled on those platforms.

## Implementation Details
- Added `path` import to handle userData directory path construction
- Cookie encryption is now conditionally enabled based on platform: `process.platform !== 'darwin'`
- Development isolation only applies to unpackaged builds (`!app.isPackaged`)

https://claude.ai/code/session_01NFfuA2n929VDd26E2ctsjT