### PR TITLE
Skip ad pattern matching for first-party requests

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -386,14 +386,15 @@ export abstract class SettingsEnforcer {
 
         // Check allowed sites (per-site disable)
         const topFrameUrl = details.frame?.url || details.referrer || '';
+        let topHostname = '';
         if (topFrameUrl) {
           try {
             const topUrl = new URL(topFrameUrl);
-            const topDomain = topUrl.hostname;
+            topHostname = topUrl.hostname;
             if (
               (currentSettings.adBlockerAllowedSites || []).some((site) => {
                 const siteDomain = site.toLowerCase().trim();
-                return topDomain === siteDomain || topDomain.endsWith('.' + siteDomain);
+                return topHostname === siteDomain || topHostname.endsWith('.' + siteDomain);
               })
             ) {
               callback({});
@@ -410,6 +411,16 @@ export abstract class SettingsEnforcer {
             callback({ cancel: true });
             return;
           }
+        }
+
+        // Skip generic URL pattern matching for first-party (same-host)
+        // requests. The patterns are designed to catch third-party ad URLs
+        // and produce false positives on legitimate site assets whose paths
+        // happen to contain generic words like "popup", "banner", or "ads"
+        // (e.g. Bitrix CMS components served under /.../popup/script.js).
+        if (topHostname && topHostname === hostname) {
+          callback({});
+          return;
         }
 
         // Check URL path patterns for ad-related content


### PR DESCRIPTION
## Summary

Prevent false positives in ad blocker URL pattern matching by skipping generic pattern checks for same-host (first-party) requests. This avoids blocking legitimate site assets whose paths contain generic words like "popup", "banner", or "ads".

## Changes

- Refactored `topDomain` variable to `topHostname` for clarity and consistency
- Added first-party request detection: compares the top-level hostname against the request hostname
- Skip generic URL pattern matching when both hostnames match, preventing false positives on legitimate site assets (e.g., Bitrix CMS components served under `/.../popup/script.js`)
- Patterns are still applied to third-party requests where they are designed to catch ad URLs

## Implementation Details

The fix introduces a new check after allowed-sites validation but before URL pattern matching. If the request originates from the same host as the top-level frame, the ad blocker patterns are bypassed entirely. This preserves the ad blocking effectiveness for cross-origin ad requests while eliminating false positives on first-party assets.

https://claude.ai/code/session_01X3vQXT7jWV9QBz94HHDZRY