### PR TITLE
Add Focus Address Bar keyboard shortcut (Cmd/Ctrl+L)

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -238,6 +238,7 @@ export abstract class MainToRendererEventsForBrowserIPC {
   public static readonly TAB_PINNED = 'browser:tab-pinned';
   public static readonly TAB_UNPINNED = 'browser:tab-unpinned';
   public static readonly FULLSCREEN_CHANGED = 'browser:fullscreen-changed';
+  public static readonly FOCUS_URL_BAR = 'browser:focus-url-bar';
 }
 
 export abstract class DataStoreConstants {

--- a/src/main/browser/app-menu-manager.ts
+++ b/src/main/browser/app-menu-manager.ts
@@ -238,6 +238,14 @@ export abstract class AppMenuManager {
           },
           { type: 'separator' as const },
           {
+            label: 'Focus Address Bar',
+            accelerator: 'CmdOrCtrl+L',
+            click: () => {
+              AppWindowManager.getActiveWindow()?.focusUrlBar();
+            },
+          },
+          { type: 'separator' as const },
+          {
             label: 'Command K Interface',
             accelerator: 'CmdOrCtrl+K',
             click: async () => {

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -572,6 +572,15 @@ export class AppWindow {
     }
   }
 
+  focusUrlBar(): void {
+    this.hideOptionsMenuOverlay();
+    this.hideCommandKOverlay();
+    this.hideCommandOOverlay();
+    if (!this.browserWindowInstance) return;
+    this.browserWindowInstance.webContents.focus();
+    this.browserWindowInstance.webContents.send(MainToRendererEventsForBrowserIPC.FOCUS_URL_BAR);
+  }
+
   broadcastToTabs(channel: string, data: any): void {
     this.tabs.forEach((tab) => {
       try {

--- a/src/preload/internals-api.ts
+++ b/src/preload/internals-api.ts
@@ -608,6 +608,9 @@ export function init() {
         callback(data)
       );
     },
+    onFocusUrlBar: (callback: () => void) => {
+      ipcRenderer.on(MainToRendererEventsForBrowserIPC.FOCUS_URL_BAR, () => callback());
+    },
     // Permission system
     respondToPermissionPrompt: (appWindowId: string, requestId: string, decision: string) => {
       ipcRenderer.send(

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -103,6 +103,7 @@ export class BrowserTabManager {
     this.backButton.title = `Go back (${isMac ? '⌘[' : 'Alt+Left'})`;
     this.forwardButton.title = `Go forward (${isMac ? '⌘]' : 'Alt+Right'})`;
     this.refreshButton.title = `Refresh (${mod}R)`;
+    this.urlInput.title = `Search or enter address (${mod}L)`;
   }
 
   private setupEventListeners(): void {
@@ -378,6 +379,12 @@ export class BrowserTabManager {
           this.updateReaderModeButton();
         }
       }
+    });
+
+    // Focus address bar (CmdOrCtrl+L)
+    window.BrowserAPI.onFocusUrlBar?.(() => {
+      this.urlInput.focus();
+      this.urlInput.select();
     });
   }
 

--- a/src/renderer/common/internals-api.ts
+++ b/src/renderer/common/internals-api.ts
@@ -257,6 +257,7 @@ declare global {
       onTabPinned: (callback: (data: { id: string }) => void) => void;
       onTabUnpinned: (callback: (data: { id: string }) => void) => void;
       onFullScreenChanged: (callback: (data: { isFullScreen: boolean }) => void) => void;
+      onFocusUrlBar: (callback: () => void) => void;
       // Permission system
       respondToPermissionPrompt: (appWindowId: string, requestId: string, decision: string) => void;
       onPermissionPromptShow: (callback: (data: any) => void) => void;

--- a/src/types/settings-types.ts
+++ b/src/types/settings-types.ts
@@ -297,6 +297,13 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: KeyboardShortcutAction[] = [
     currentShortcut: 'mod+F',
   },
   {
+    id: 'focus-address-bar',
+    label: 'Focus Address Bar',
+    category: 'Navigation',
+    defaultShortcut: 'mod+L',
+    currentShortcut: 'mod+L',
+  },
+  {
     id: 'open-settings',
     label: 'Open Settings',
     category: 'Utilities',


### PR DESCRIPTION
## Summary
Adds support for focusing and selecting the address bar via the keyboard shortcut `Cmd/Ctrl+L`, a standard browser convention. This allows users to quickly navigate to the address bar without using the mouse.

## Key Changes

- **Main Process (`app-window.ts`)**: Added `focusUrlBar()` method that hides overlays, focuses the browser window, and sends an IPC event to the renderer to focus the address bar
- **Menu Integration (`app-menu-manager.ts`)**: Added "Focus Address Bar" menu item under the navigation section with `CmdOrCtrl+L` accelerator
- **Renderer (`browser-manager.ts`)**: 
  - Added listener for the `FOCUS_URL_BAR` IPC event that focuses and selects the URL input field
  - Updated URL input tooltip to document the keyboard shortcut
- **Settings (`settings-types.ts`)**: Added keyboard shortcut configuration entry for "Focus Address Bar" in the default shortcuts list
- **IPC Layer**:
  - Added `FOCUS_URL_BAR` constant to `MainToRendererEventsForBrowserIPC`
  - Added `onFocusUrlBar` callback handler in preload API (`internals-api.ts`)
  - Added type declaration for `onFocusUrlBar` in renderer globals (`internals-api.ts`)

## Implementation Details

The implementation follows the established IPC communication pattern:
1. User presses `Cmd/Ctrl+L` or selects menu item
2. Main process calls `focusUrlBar()` which hides any open overlays (options menu, command K, command O)
3. Main process sends `FOCUS_URL_BAR` IPC event to renderer
4. Renderer receives event and focuses/selects the URL input field for immediate text entry

This provides a seamless keyboard-driven navigation experience consistent with other modern browsers.

https://claude.ai/code/session_0127HB11DuNEs82eQnGM6BAt