### PR TITLE
Handle unavailable checksums in about page

### DIFF
--- a/src/renderer/pages/about/index.ts
+++ b/src/renderer/pages/about/index.ts
@@ -16,6 +16,17 @@ const ARCH_NAMES: Record<string, string> = {
   ia32: 'x86 (32-bit)',
 };
 
+function setChecksumRow(elementId: string, value: string): void {
+  const el = document.getElementById(elementId);
+  if (!el) return;
+  if (value === 'unavailable') {
+    const row = el.closest('.about-row') as HTMLElement | null;
+    if (row) row.style.display = 'none';
+    return;
+  }
+  el.textContent = value;
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     const info = await window.BrowserAPI.getAboutInfo();
@@ -30,8 +41,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('arch').textContent = ARCH_NAMES[info.arch] || info.arch;
     document.getElementById('os-version').textContent = info.osVersion || '--';
     document.getElementById('app-path').textContent = info.appPath;
-    document.getElementById('executable-checksum').textContent = info.executableChecksum;
-    document.getElementById('asar-checksum').textContent = info.asarChecksum;
+    setChecksumRow('executable-checksum', info.executableChecksum);
+    setChecksumRow('asar-checksum', info.asarChecksum);
   } catch (err) {
     console.error('Failed to load about info:', err);
   }


### PR DESCRIPTION
## Summary

Refactors checksum display logic in the about page to gracefully handle cases where checksums are unavailable, hiding the entire row instead of displaying placeholder text.

## Changes

- **New helper function**: Added `setChecksumRow()` to centralize checksum row rendering logic
  - Hides the entire `.about-row` when checksum value is `'unavailable'`
  - Sets element text content for available checksums
  - Safely handles missing DOM elements
- **Updated checksum assignments**: Replaced direct `textContent` assignments with `setChecksumRow()` calls for both executable and ASAR checksums

## Implementation Details

The new `setChecksumRow()` function:
- Takes an element ID and checksum value as parameters
- Returns early if the element doesn't exist (defensive programming)
- Checks for the special `'unavailable'` string value to determine visibility
- Uses `closest('.about-row')` to find and hide the parent row container when checksums aren't available
- Falls back to standard text content assignment for valid checksums

This approach provides a cleaner UI by removing empty checksum rows entirely rather than showing unavailable/placeholder values.

https://claude.ai/code/session_01KC2JqPSuAhHP8f5ZC9Tm8U