### PR TITLE
Bump version to 0.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Nav0",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Nav0",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Nav0",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A minimal, privacy-focused web browser built on Electron",
   "private": true,
   "main": ".webpack/main",


### PR DESCRIPTION
## Summary
This release bumps the Nav0 browser version from 0.2.8 to 0.2.9.

## Changes
- Updated `package.json` version field from `0.2.8` to `0.2.9`

This is a routine version bump for a new release.

https://claude.ai/code/session_014xDuZkfcoQKvTUqfhbMA3c