### PR TITLE
Fix URL autocomplete navigation to include unselected state

### DIFF
--- a/src/renderer/browser-layout/url-autocomplete.ts
+++ b/src/renderer/browser-layout/url-autocomplete.ts
@@ -116,7 +116,13 @@ const closeDropdown = () => {
 
 const navigate = (direction: number) => {
   if (currentResults.length === 0) return;
-  activeIndex = (activeIndex + direction + currentResults.length) % currentResults.length;
+  // From the unselected state (-1), ArrowDown lands on the first item and ArrowUp
+  // lands on the last item.
+  if (activeIndex < 0) {
+    activeIndex = direction > 0 ? 0 : currentResults.length - 1;
+  } else {
+    activeIndex = (activeIndex + direction + currentResults.length) % currentResults.length;
+  }
   pushToOverlay(false);
 };
 
@@ -223,7 +229,9 @@ const fetchSuggestions = async (query: string) => {
     }
 
     currentResults = results;
-    activeIndex = results.length > 0 ? 0 : -1;
+    // Leave no suggestion highlighted by default so pressing Enter navigates to
+    // whatever the user typed. They can ArrowDown/ArrowUp to pick a suggestion.
+    activeIndex = -1;
     if (results.length > 0) pushToOverlay(true);
     else closeDropdown();
   } catch {
@@ -236,7 +244,7 @@ const fetchSuggestions = async (query: string) => {
         meta: 'Search with default search engine',
       },
     ];
-    activeIndex = 0;
+    activeIndex = -1;
     pushToOverlay(true);
   }
 };

--- a/src/renderer/browser-layout/url-autocomplete.ts
+++ b/src/renderer/browser-layout/url-autocomplete.ts
@@ -116,13 +116,14 @@ const closeDropdown = () => {
 
 const navigate = (direction: number) => {
   if (currentResults.length === 0) return;
-  // From the unselected state (-1), ArrowDown lands on the first item and ArrowUp
-  // lands on the last item.
-  if (activeIndex < 0) {
-    activeIndex = direction > 0 ? 0 : currentResults.length - 1;
-  } else {
-    activeIndex = (activeIndex + direction + currentResults.length) % currentResults.length;
-  }
+  // The unselected state (-1) is part of the cycle, so the user can always get
+  // back to "no suggestion highlighted" and press Enter to navigate to the typed
+  // input. Cycle order going down: -1 → 0 → 1 → ... → N-1 → -1.
+  const n = currentResults.length;
+  const next = activeIndex + direction;
+  if (next >= n) activeIndex = -1;
+  else if (next < -1) activeIndex = n - 1;
+  else activeIndex = next;
   pushToOverlay(false);
 };
 


### PR DESCRIPTION
## Summary

Improves the URL autocomplete dropdown navigation behavior by including the unselected state (-1) in the navigation cycle. This allows users to always return to "no suggestion highlighted" and press Enter to navigate to their typed input, rather than being forced to select a suggestion.

## Changes

- **Navigation cycle logic**: Modified `navigate()` to cycle through states including -1 (unselected), so the order is: -1 → 0 → 1 → ... → N-1 → -1. Previously, the cycle skipped the unselected state.

- **Default selection on fetch**: Changed `fetchSuggestions()` to initialize `activeIndex` to -1 instead of 0, so suggestions are not auto-selected when results appear. Users must explicitly navigate to a suggestion using arrow keys.

- **Fallback search initialization**: Updated the fallback search engine suggestion to also start with `activeIndex = -1` for consistency.

## Implementation Details

The navigation logic now explicitly handles boundary conditions:
- When navigating down past the last result, wrap to -1 (unselected)
- When navigating up past -1, wrap to the last result
- Otherwise, move to the next index

This gives users full control: they can press Enter on their typed query without being forced to accept a suggestion, while still being able to browse suggestions with arrow keys.

https://claude.ai/code/session_01R5GbvNztwGt7UXbTuspavP