### PR TITLE
docs: Update CLAUDE.md for v0.2.9 architecture and tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@
 
 Nav0 is a minimal, privacy-focused web browser built on Electron. The philosophy is **"Browse. Nothing More."** — a lightweight, open-source browser with zero telemetry, zero tracking, and zero data collection.
 
-- **Version**: 0.1.1
+- **Version**: 0.2.9
 - **License**: MIT
 - **Author**: Ketan Patil
 - **Repo**: https://github.com/nav0-org/nav0-browser
+- **Docs site**: lives in a separate repo at https://github.com/nav0-org/website
 
 ## Quick Reference
 
@@ -15,13 +16,18 @@ Nav0 is a minimal, privacy-focused web browser built on Electron. The philosophy
 npm run start          # Run in development mode (electron-forge start)
 npm run make           # Build distributable packages
 npm run package        # Package without creating distributables
-npm run lint           # Run ESLint on .ts/.tsx files
+npm run lint           # Run all linters (ts, css, html)
+npm run lint:ts        # Run ESLint on .ts/.tsx files
+npm run lint:css       # Run Stylelint on .css files
+npm run lint:html      # Run HTMLHint on src/**/*.html
+npm run format         # Run Prettier across the repo
+npm run format:check   # Verify formatting without writing
 npm run test:perf      # Run Puppeteer-based performance tests
 npm run test:data      # Run data consumption tests
 npm run rebuild        # Rebuild native modules (better-sqlite3)
-npm run docs:dev       # Start VitePress docs dev server
-npm run docs:build     # Build documentation site
 ```
+
+Husky runs `lint-staged` on every commit (see `package.json` → `lint-staged`), so staged files get ESLint/Stylelint/HTMLHint + Prettier automatically.
 
 ## Architecture
 
@@ -29,39 +35,59 @@ npm run docs:build     # Build documentation site
 
 ```
 Main Process (src/main/)          Renderer Process (src/renderer/)
-├── Browser managers              ├── Browser layout (tabs, nav)
-├── Database (SQLite)             ├── Built-in pages (history, etc.)
-├── Settings enforcement          ├── Overlays (command-k, find, etc.)
-├── Ad blocker                    └── Common utilities
+├── Browser managers              ├── Browser layout (tabs, nav, find, perms)
+├── Database (SQLite)             ├── Built-in pages (history, bookmarks, …)
+├── Settings enforcement          ├── Unified overlay (command-k, alerts, …)
+├── Ad blocker                    ├── Display-capture picker
+├── CLI args & installer          └── Common utilities
+├── Session restore
 └── Window/tab lifecycle
         ↕ IPC via preload scripts (src/preload/)
 ```
 
-- **Main process** (`src/main/`): System-level operations — window management, database, settings, downloads, permissions, ad blocking, SSL
-- **Renderer process** (`src/renderer/`): All UI — browser chrome, built-in pages, overlays, menus
+- **Main process** (`src/main/`): System-level operations — window management, database, settings, downloads, permissions, ad blocking, SSL, notifications, session restore, CLI handling
+- **Renderer process** (`src/renderer/`): All UI — browser chrome, built-in pages, the unified overlay, the display-capture picker
 - **Preload scripts** (`src/preload/`): IPC bridges exposing safe APIs to renderer via `contextBridge`
 
 ### Manager Pattern
 
 Every feature is encapsulated in a manager class:
 
-| Manager                  | Location             | Purpose                                       |
-| ------------------------ | -------------------- | --------------------------------------------- |
-| `AppWindowManager`       | `src/main/browser/`  | Window lifecycle, multi-window support        |
-| `AppWindow`              | `src/main/browser/`  | Single window with tabs and overlays          |
-| `Tab`                    | `src/main/browser/`  | Individual tab (WebContentsView)              |
-| `DatabaseManager`        | `src/main/database/` | SQLite connection management                  |
-| `SchemaManager`          | `src/main/database/` | Database schema versioning                    |
-| `DataStoreManager`       | `src/main/database/` | electron-store key-value wrapper              |
-| `DownloadManager`        | `src/main/browser/`  | Download tracking and control                 |
-| `BookmarkManager`        | `src/main/browser/`  | Bookmark CRUD operations                      |
-| `PermissionManager`      | `src/main/browser/`  | Site permission policies                      |
-| `SettingsEnforcer`       | `src/main/settings/` | Applies user preferences to sessions          |
-| `ReaderModeManager`      | `src/main/browser/`  | Reader mode extraction (@mozilla/readability) |
-| `SSLManager`             | `src/main/browser/`  | Certificate validation                        |
-| `FindInPageManager`      | `src/main/browser/`  | In-page text search                           |
-| `CommandKOverlayManager` | `src/main/browser/`  | Command palette overlay                       |
-| `CommandOOverlayManager` | `src/main/browser/`  | File opener overlay                           |
+| Manager                  | Location             | Purpose                                           |
+| ------------------------ | -------------------- | ------------------------------------------------- |
+| `AppWindowManager`       | `src/main/browser/`  | Window lifecycle, multi-window support            |
+| `AppWindow`              | `src/main/browser/`  | Single window with tabs and overlays              |
+| `Tab`                    | `src/main/browser/`  | Individual tab (WebContentsView)                  |
+| `AppMenuManager`         | `src/main/browser/`  | Native application menu (File/Edit/View/…)        |
+| `SessionManager`         | `src/main/browser/`  | Persists/restores open windows + tabs on relaunch |
+| `UnifiedOverlayManager`  | `src/main/browser/`  | Hosts all overlay panels in one WebContentsView   |
+| `NotificationManager`    | `src/main/browser/`  | Web Notification API with per-origin gating       |
+| `DatabaseManager`        | `src/main/database/` | SQLite connection management (normal + private)   |
+| `SchemaManager`          | `src/main/database/` | Database schema versioning                        |
+| `DataStoreManager`       | `src/main/database/` | electron-store key-value wrapper                  |
+| `DownloadManager`        | `src/main/browser/`  | Download tracking and control                     |
+| `BookmarkManager`        | `src/main/browser/`  | Bookmark CRUD operations                          |
+| `BrowsingHistoryManager` | `src/main/browser/`  | Browsing history CRUD                             |
+| `PermissionManager`      | `src/main/browser/`  | Site permission policies + prompts                |
+| `SettingsEnforcer`       | `src/main/settings/` | Applies user preferences to sessions              |
+| `ReaderModeManager`      | `src/main/browser/`  | Reader mode extraction (@mozilla/readability)     |
+| `SSLManager`             | `src/main/browser/`  | Certificate validation + interstitial page        |
+| `FindInPageManager`      | `src/main/browser/`  | In-page text search                               |
+| `SearchEngine`           | `src/main/web/`      | Selects the active search engine + suggestions    |
+| `CLIInstaller`           | `src/main/cli/`      | Installs `nav0` shim into PATH (macOS/Windows)    |
+| UA switcher              | `src/main/browser/ua-switcher.ts` | Strips "Electron/…" from UA + aligns Client Hints |
+
+### Unified overlay system
+
+All the modal-ish UI (command palette, options menu, SSL info, issue report, alerts, basic auth, URL autocomplete dropdown) lives in a single overlay `WebContentsView` per window instead of one renderer per overlay:
+
+- Main process: `src/main/browser/unified-overlay-manager.ts` + handlers in `src/main/browser/overlay-handlers/`
+  - `command-k-handler.ts`, `command-o-handler.ts`, `options-menu-handler.ts`, `issue-report-handler.ts`, `ssl-info-handler.ts`, `alert-handler.ts`, `basic-auth-handler.ts`, `url-autocomplete-handler.ts`
+- Renderer: `src/renderer/overlay/` with one panel per overlay in `src/renderer/overlay/panels/`
+
+When adding a new overlay, add a handler in `overlay-handlers/`, a panel in `renderer/overlay/panels/`, register it in `unified-overlay-manager.ts` and `renderer/overlay/index.ts`, and wire IPC channels in `app-constants.ts`. You do **not** need a new webpack entry point.
+
+The display-capture picker is the one exception — it's a separate small renderer at `src/renderer/pages/display-capture-picker/` with its own preload (`src/preload/display-capture-picker-preload.ts`) because it has to load synchronously during `desktopCapturer` handling.
 
 ### IPC Communication
 
@@ -70,112 +96,203 @@ All IPC channels are defined as string constants in `src/constants/app-constants
 - `RendererToMainEventsForBrowserIPC` — renderer-initiated browser actions
 - `MainToRendererEventsForBrowserIPC` — main process responses to renderer
 - `RendererToMainEventsForDataStoreIPC` — data operations (CRUD for bookmarks, history, etc.)
+- Plus `ElectronAppEvents` and `WebContentsEvents` for typed Electron event names
 
 Always use these constants for IPC channel names — never hardcode strings.
 
 ### Database Architecture
 
 - **Engine**: better-sqlite3 (native SQLite bindings)
-- **Dual database system**: Separate databases for normal and private browsing
-  - Private database is deleted when the private window closes
+- **Dual database**: a persistent DB on disk and a separate **in-memory** DB for private browsing — private data never touches disk
+  - On startup, `DatabaseManager` deletes any leftover `private-database.db` from old builds
 - **Schemas** defined in `src/main/database/schema/`:
   - `bookmark-schema.ts`
   - `browsing-history-schema.ts`
   - `download-schema.ts`
   - `permission-schema.ts`
 
+### Sessions / partitions
+
+Defined in `PartitionNames` (`src/constants/app-constants.ts`):
+
+- `persist:browsertabs` — the normal browsing session (persisted to `<userData>/Partitions/browsertabs/`)
+- `private` — the private window session, intentionally **without** the `persist:` prefix so Chromium keeps it in memory only
+
+Startup also wipes any leftover `<userData>/Partitions/private/` directory from older builds that used a persistent private partition.
+
 ### Settings System
 
 - Settings interface: `BrowserSettings` in `src/types/settings-types.ts` (~80+ configurable options)
 - Stored via `electron-store` (DataStoreManager)
 - Applied centrally through `SettingsEnforcer` which handles:
-  - Cookie policies, proxy config, user agent
-  - Ad blocker toggle, auto-deletion scheduling
+  - Cookie policies, proxy config, user agent (in concert with `ua-switcher`)
+  - Ad blocker toggle, auto-deletion scheduling, popup policy, keyboard shortcuts
+
+### Session restore
+
+`SessionManager` (`src/main/browser/session-manager.ts`) snapshots the open windows + tabs to the `session-state` key in `electron-store` every 60s and on quit. The recently-closed list and closed-windows list are also stored there (`closed-windows` key, `ClosedTabRecord` / `ClosedWindowRecord` types in `app-constants.ts`).
+
+### CLI launch flags
+
+`src/main/cli/cli-args.ts` parses Nav0-specific flags out of `process.argv`:
+
+- `-p`, `--private` — open in a private window
+- `-u <url> [<url> …]`, `--url <url> [<url> …]` — open URLs as tabs in a new window
+
+A single-instance lock in `src/main/index.ts` routes subsequent `nav0 …` invocations to the running instance via the `second-instance` event, so `nav0 -u example.com` from a second terminal opens a tab in the existing app rather than spawning a duplicate.
+
+`CLIInstaller` (`src/main/cli/cli-installer.ts`) installs the shim:
+
+- macOS: symlinks `/usr/local/bin/nav0` → the app binary (asks for sudo via AppleScript)
+- Windows: drops `nav0.cmd` into `%LocalAppData%\Microsoft\WindowsApps`
 
 ## Source Structure
 
 ```
 src/
 ├── main/                          # Electron main process
-│   ├── index.ts                   # App entry point
-│   ├── browser/                   # Core browser managers (19 files)
+│   ├── index.ts                   # App entry: error handlers, single-instance lock, CLI dispatch
+│   ├── test-control-server.ts     # Tiny HTTP server enabled when REMOTE_DEBUGGING_PORT is set (perf tests)
+│   ├── browser/                   # Core browser managers
+│   │   ├── app-window-manager.ts
+│   │   ├── app-window.ts
+│   │   ├── app-menu-manager.ts
+│   │   ├── tab.ts
+│   │   ├── session-manager.ts
+│   │   ├── unified-overlay-manager.ts
+│   │   ├── notification-manager.ts
+│   │   ├── download-manager.ts
+│   │   ├── bookmark-manager.ts
+│   │   ├── browsing-history-manager.ts
+│   │   ├── permission-manager.ts
+│   │   ├── reader-mode-manager.ts
+│   │   ├── find-in-page-manager.ts
+│   │   ├── ssl-manager.ts
+│   │   ├── ssl-warning-page.{ts,html}
+│   │   ├── ua-switcher.ts         # Strips "Electron/…" from UA + aligns Client Hints
+│   │   ├── utils.ts
+│   │   ├── error-page/            # Custom error page shown on navigation failure
+│   │   └── overlay-handlers/      # One handler per overlay panel (8 files)
+│   ├── cli/                       # CLI flag parsing + PATH installer
+│   │   ├── cli-args.ts
+│   │   └── cli-installer.ts
 │   ├── database/                  # SQLite layer + schemas
+│   │   ├── database-manager.ts
+│   │   ├── schema-manager.ts
+│   │   ├── data-store-manager.ts
+│   │   └── schema/
 │   ├── settings/                  # Settings enforcement
+│   │   └── settings-enforcer.ts
 │   ├── web/                       # Search engine configuration
+│   │   └── search-engine.ts
 │   └── ad-blocker/                # Domain lists, URL patterns, CSS injection
+│       └── ad-block-lists.ts
 ├── renderer/                      # Electron renderer process
-│   ├── browser-layout/            # Main browser UI (tabs, navigation bar)
+│   ├── browser-layout/            # Main browser UI (tabs, nav bar, find-in-page, permission strip, autocomplete)
+│   ├── overlay/                   # Unified overlay window
+│   │   ├── index.{html,ts,css}
+│   │   └── panels/                # One panel per overlay type:
+│   │       ├── command-k/
+│   │       ├── command-o/
+│   │       ├── options-menu/
+│   │       ├── issue-report/
+│   │       ├── ssl-info/
+│   │       ├── alert/             #   alert / confirm / prompt
+│   │       ├── basic-auth/
+│   │       └── url-autocomplete/
 │   ├── pages/                     # Built-in pages
-│   │   ├── about/                 #   About page
-│   │   ├── bookmarks/             #   Bookmarks viewer
-│   │   ├── browser-settings/      #   Settings UI
-│   │   ├── command-k/             #   Command palette
-│   │   ├── command-o/             #   File opener
-│   │   ├── downloads/             #   Downloads viewer
-│   │   ├── history/               #   History viewer
-│   │   └── new-tab/               #   New tab page
-│   ├── options-menu/              # Browser menu
-│   ├── permission-prompt/         # Permission request dialogs
-│   ├── issue-report/              # Bug report UI
-│   ├── web-content/               # Web page rendering
-│   ├── find-in-page/              # Find in page UI
-│   ├── ssl-info/                  # SSL certificate info
-│   ├── common/                    # Shared utilities (theme, html, format)
+│   │   ├── about/
+│   │   ├── bookmarks/
+│   │   ├── browser-settings/
+│   │   ├── display-capture-picker/  # screen/window picker for getDisplayMedia
+│   │   ├── downloads/
+│   │   ├── history/
+│   │   └── new-tab/
+│   ├── web-content/               # Web page rendering host
+│   ├── common/                    # Shared utilities (api wrappers, formatters, html helpers, file types)
 │   ├── assets/                    # Images, icons, logos
-│   └── styles/                    # CSS stylesheets
+│   └── styles/                    # Shared CSS (global.css, notification.css)
 ├── preload/                       # IPC bridge scripts
-│   ├── internals-api.ts           # Main API for internal pages
-│   ├── externals-api.ts           # External-facing API
-│   └── web-content-preload.ts     # Web content preload
+│   ├── internals-api.ts           # DataStoreAPI + BrowserAPI for internal pages and the overlay
+│   ├── externals-api.ts           # Externally facing API for web content
+│   ├── web-content-preload.ts     # Preload for web-content host
+│   └── display-capture-picker-preload.ts  # Preload specific to the picker
 ├── types/                         # Shared TypeScript interfaces
 │   ├── bookmark-record.ts
 │   ├── browsing-history-record.ts
 │   ├── download-record.ts
+│   ├── dialog-types.ts            # alert/confirm/prompt + basic-auth payloads
 │   └── settings-types.ts
 └── constants/
-    └── app-constants.ts           # IPC channels, URLs, data store keys
+    ├── app-constants.ts           # IPC channels, in-app URLs, partition names, data store keys, etc.
+    └── data-constants.ts          # Domain → website-category map for bookmarks/history grouping
 
 tests/
 └── performance/                   # Puppeteer-based tests
     ├── browser-perf-test.js       # CPU/memory/frame benchmarks (10-50 tabs)
-    └── data-consumption-test.js   # Network usage metrics
+    ├── browser-perf-test-mac.js   # macOS-specific perf harness
+    ├── chrome-harness.js          # Chrome baseline used for comparison
+    ├── data-consumption-test.js   # Network usage metrics
+    └── reports/                   # Generated test reports
 
-docs/                              # VitePress documentation site
-├── .vitepress/                    # VitePress config and theme
-├── blog/                          # Privacy-focused blog posts
-├── releases/                      # Release notes (v0.0.4 - v0.0.9)
-└── guide/                         # User documentation
+.github/workflows/
+└── build-electron.yml             # Multi-platform release build
 ```
+
+Documentation (VitePress site, blog posts, release notes) lives in the separate **nav0-org/website** repo — there is no `docs/` directory in this repo anymore.
 
 ## Tech Stack
 
-| Component       | Technology                    | Version |
-| --------------- | ----------------------------- | ------- |
-| Runtime         | Electron                      | 35.2.1  |
-| Language        | TypeScript                    | 5.8.3   |
-| Bundler         | Webpack (via @electron-forge) | —       |
-| Build Tool      | Electron Forge                | 7.8.0   |
-| Database        | better-sqlite3                | 11.9.1  |
-| Key-Value Store | electron-store                | 8.2.0   |
-| Reader Mode     | @mozilla/readability          | 0.6.0   |
-| Icons           | Lucide                        | 0.503.0 |
-| Docs            | VitePress                     | 1.5.0   |
-| Testing         | Puppeteer Core                | 24.37.5 |
+| Component       | Technology                               | Version |
+| --------------- | ---------------------------------------- | ------- |
+| Runtime         | Electron                                 | 41.0.0  |
+| Language        | TypeScript                               | 5.8.3   |
+| Bundler         | Webpack (via @electron-forge)            | —       |
+| Build Tool      | Electron Forge                           | 7.10.x  |
+| Database        | better-sqlite3                           | 12.9.0  |
+| Key-Value Store | electron-store                           | 8.2.0   |
+| Reader Mode     | @mozilla/readability                     | 0.6.0   |
+| PDF parsing     | pdf-parse                                | 1.1.1   |
+| Markdown        | marked                                   | 15.0.11 |
+| UUIDs           | uuid                                     | 11.1.0  |
+| Promises        | bluebird                                 | 3.7.2   |
+| Icons           | Lucide                                   | 0.503.0 |
+| Testing         | Puppeteer Core                           | 24.42.x |
+| Lint / Format   | ESLint + Stylelint + HTMLHint + Prettier | —       |
+| Git hooks       | Husky + lint-staged                      | —       |
 
 ## Build & Configuration
 
 ### Webpack
 
 - `webpack.main.config.ts` — Main process bundling
-- `webpack.renderer.config.ts` — Renderer bundling (15 entry points)
+- `webpack.renderer.config.ts` — Renderer bundling
 - `webpack.rules.ts` — Shared loader rules (includes `@vercel/webpack-asset-relocator-loader` for native modules)
 - `webpack.plugins.ts` — Shared plugins (Fork TS Checker for type checking)
 
 ### Electron Forge (`forge.config.ts`)
 
-- **Makers**: DMG (macOS), ZIP, DEB (Linux), RPM, Squirrel (Windows)
-- **ESM Workaround**: `packageAfterPrune` hook patches Electron 35+ native module loading
+- **Makers**: DMG (macOS), ZIP (macOS), DEB (Linux), RPM (Linux), Squirrel (Windows)
+- **Fuses** (`@electron-forge/plugin-fuses`):
+  - `RunAsNode` off
+  - `EnableCookieEncryption` is **off on macOS** (no Developer ID signing → OSCrypt can't persist its key in the Keychain → users get logged out on next launch) and on everywhere else
+  - `EnableNodeOptionsEnvironmentVariable` / `EnableNodeCliInspectArguments` off
+  - `EnableEmbeddedAsarIntegrityValidation` + `OnlyLoadAppFromAsar` on
+- **ESM Workaround**: `packageAfterPrune` hook rewrites `package.json` `main` from `.webpack/main` to `.webpack/main/index.js` because Electron 35+ uses ESM resolution and rejects the directory form.
 - **Native rebuild**: `better-sqlite3` rebuilt via `electron-rebuild`
+- **Linux binary name**: lowercase `nav0` (the deb/rpm makers require lowercase).
+
+### Webpack renderer entry points
+
+Defined in `forge.config.ts`. After the overlay consolidation, the entries are:
+
+1. `browser_layout` — main browser chrome
+2. `bookmarks`, `browser_settings`, `downloads`, `history`, `new_tab`, `about` — built-in pages
+3. `web_content` — host for web pages
+4. `overlay` — unified overlay (replaces the old `command_k`, `command_o`, `options_menu`, `permission_prompt`, `issue_report`, `ssl_info`, `find_in_page` entries)
+5. `display_capture_picker` — the screen/window source picker
+
+When adding a new overlay, **do not** add a new entry — register it inside the existing `overlay` entry (see "Unified overlay system" above). New top-level pages still get their own entry.
 
 ### TypeScript (`tsconfig.json`)
 
@@ -183,11 +300,13 @@ docs/                              # VitePress documentation site
 - Module: CommonJS
 - Strict: `noImplicitAny: true`
 
-### ESLint (`.eslintrc.json`)
+### Linting & formatting
 
-- Parser: `@typescript-eslint/parser`
-- Extends: `eslint:recommended`, `@typescript-eslint/recommended`, `plugin:import/recommended`
-- Environments: browser, es6, node
+- ESLint: `.eslintrc.json` — `@typescript-eslint/parser`, extends `eslint:recommended`, `@typescript-eslint/recommended`, `plugin:import/recommended`, `plugin:import/electron`, `plugin:import/typescript`, and `prettier` (so format rules don't fight)
+- Prettier: `.prettierrc.json` — 100 col, single quotes, semis, trailing commas (es5), LF
+- Stylelint: `.stylelintrc.json` — extends `stylelint-config-standard` with most opinionated rules turned off
+- HTMLHint: `.htmlhintrc`
+- Husky pre-commit hook (`.husky/pre-commit`) runs `npx lint-staged`, which runs the relevant linter + Prettier on staged files (see `lint-staged` block in `package.json`).
 
 ## CI/CD
 
@@ -198,9 +317,9 @@ docs/                              # VitePress documentation site
   - Ubuntu Latest (x64) → DEB + RPM
   - Windows Latest (x64) → EXE
   - Node 22, Python 3.11
-  - Trigger: `workflow_dispatch` with optional version override
+  - Trigger: `workflow_dispatch` with optional version override + `prerelease` toggle
 
-- **`docs.yml`**: Documentation deployment on push
+Documentation deployment lives in the **nav0-org/website** repo and is not built from this one.
 
 ## Design Principles
 
@@ -226,22 +345,39 @@ When contributing to Nav0, always keep these principles in mind:
 ### Native Modules (better-sqlite3)
 
 - Requires `electron-rebuild` after install: `npm run rebuild`
+- A `postinstall` script does this automatically on `npm install`
 - Webpack uses `@vercel/webpack-asset-relocator-loader` in the main process to handle native `.node` bindings
 - The `node-loader` handles `.node` file imports
 
 ### Electron 35+ ESM Workaround
 
-- `forge.config.ts` has a `packageAfterPrune` hook that patches `package.json` files in node_modules to fix ESM/CJS compatibility issues
-- This is critical for native module loading — do not remove
+- `forge.config.ts` has a `packageAfterPrune` hook that rewrites `package.json`'s `main` to `.webpack/main/index.js`
+- This is critical for native module loading and main process entry — do not remove
+
+### Cookie encryption fuse (macOS)
+
+- `EnableCookieEncryption` is intentionally disabled on macOS in unsigned builds. Without an Apple Developer ID, OSCrypt can't reliably persist its key in the Keychain, so cookies become unreadable on the next launch and users get logged out. Keep this guarded by `process.platform !== 'darwin'` until the app is properly signed.
+
+### Private browsing data must not hit disk
+
+- Private windows use the **in-memory** SQLite DB (`:memory:`) and a non-persistent Electron session partition (`'private'`, without the `persist:` prefix). Anything you add that writes per-window data needs to honour both — don't shove private-window state into the persistent `electron-store`, and don't open new SQLite tables on the regular `db` for private contexts.
+
+### Dev vs. installed userData
+
+- When `!app.isPackaged`, the userData path is overridden to `<appData>/Nav0 (Dev)` so dev sessions don't clobber the installed app's cookies/history/settings. Anything that hard-codes paths under `app.getPath('userData')` needs to keep working under both.
+
+### User-Agent / Client Hints
+
+- `configureUserAgentFallback()` (`src/main/browser/ua-switcher.ts`) must run **before** any `BrowserWindow` / `WebContentsView` is created — `src/main/index.ts` already does this at the top of the module. Cloudflare Turnstile and similar bot detectors cross-check the UA against the `Sec-CH-UA` headers; this module also rewrites those headers so they line up.
 
 ### Environment Variables
 
-- `NAV0_ISSUE_API_KEY` — Used in webpack renderer config for issue reporting
-- `REMOTE_DEBUGGING_PORT` — Enables remote debugging (used in tests)
+- `NAV0_ISSUE_API_KEY` — Used in webpack renderer config for the in-app issue reporter
+- `REMOTE_DEBUGGING_PORT` — When set, `startTestControlServer` exposes a small HTTP API used by the Puppeteer perf tests
 
-### Renderer Entry Points
+### Single-instance + CLI
 
-There are 15 separate webpack entry points for different renderer windows/overlays. When adding new UI, create a new entry point in `forge.config.ts` and `webpack.renderer.config.ts`.
+- The app holds a single-instance lock. Code that adds new CLI flags should extend `parseCLIArgs` (`src/main/cli/cli-args.ts`) **and** the `second-instance` handler in `src/main/index.ts` so flags work from both the first and subsequent invocations.
 
 ## Code Conventions
 
@@ -251,160 +387,9 @@ There are 15 separate webpack entry points for different renderer windows/overla
 - Define data types as interfaces in `src/types/`
 - Use the existing database schema pattern when adding new data models
 - Keep renderer code separate from main process code — communicate via IPC only
-- No inline styles — use CSS files in `src/renderer/styles/`
-
-## Writing Blog Posts
-
-Blog posts live in `docs/blog/`. The sidebar and index are auto-generated from frontmatter.
-
-### Steps to add a new blog post
-
-1. **Create the markdown file** at `docs/blog/<slug>.md` (use kebab-case for the filename)
-2. **Add frontmatter** with the following required fields:
-
-```yaml
----
-title: 'Your Post Title Here'
-description: 'A concise description for SEO and social sharing.'
-date: 2026-03-21
-author: Nav0 Team
-tags: [privacy, browsers]
-head:
-  - - meta
-    - property: og:type
-      content: article
-  - - meta
-    - property: article:published_time
-      content: '2026-03-21'
-  - - meta
-    - property: article:author
-      content: Nav0 Team
-  - - meta
-    - property: article:tag
-      content: privacy
-  - - script
-    - type: application/ld+json
-    - |
-      {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Your Post Title Here",
-        "description": "A concise description for SEO and social sharing.",
-        "datePublished": "2026-03-21",
-        "author": { "@type": "Organization", "name": "Nav0" },
-        "publisher": { "@type": "Organization", "name": "Nav0", "url": "https://nav0.org", "logo": { "@type": "ImageObject", "url": "https://nav0.org/logo.svg" } },
-        "mainEntityOfPage": "https://nav0.org/blog/<slug>",
-        "keywords": ["privacy", "browsers"]
-      }
----
-```
-
-3. **Write the post content** in markdown. Start with an `h1` heading matching the title, followed by the byline:
-
-```md
-# Your Post Title Here
-
-<p style="color: var(--vp-c-text-2); font-size: 0.9rem;">By Nav0 Team &middot; March 21, 2026 &middot; 8 min read</p>
-
-Your content here...
-```
-
-4. **End with the Nav0 CTA footer:**
-
-```md
----
-
-_Nav0 is a minimal, privacy-focused browser that collects zero data. It's open source, free, and built on the belief that your browser should do one thing well: let you browse the web. [Get started](/guide/getting-started)._
-```
-
-5. **Add the entry to `docs/blog/index.md`** at the top of the list (newest first):
-
-```html
-<div class="blog-post-item">
-  <a href="/blog/<slug>">
-    <h2>Your Post Title Here</h2>
-  </a>
-  <div class="post-meta">
-    By Nav0 Team &middot; March 21, 2026 &middot; 8 min read &middot; Category
-  </div>
-  <p class="post-excerpt">A brief excerpt summarizing the post (1-2 sentences).</p>
-</div>
-```
-
-### Blog conventions
-
-- Categories used: Privacy, Security, Comparison, Performance, Data Consumption, AI & Bloat, Open Web
-- Author is always "Nav0 Team"
-- Include reading time estimate in the byline
-- All posts should align with Nav0's privacy-first philosophy
-- The sidebar is auto-generated from frontmatter by `getBlogSidebar()` in `docs/.vitepress/config.ts`
-
-## Writing Release Notes
-
-Release notes live in `docs/releases/`. The sidebar is auto-generated from frontmatter.
-
-### Steps to add a new release
-
-1. **Create the markdown file** at `docs/releases/v<version>.md` (e.g., `v0.1.0.md`)
-2. **Add frontmatter:**
-
-```yaml
----
-title: 'v0.1.0'
-date: 2026-03-21
-badge: Latest
----
-```
-
-- Use `badge: Latest` only for the newest release. Remove `badge` from the previous latest release file.
-- For alpha releases, use `badge: Alpha` and name the file `v<version>-alpha.md`.
-
-3. **Write the release content** with this structure:
-
-```md
-# v0.1.0
-
-<span class="release-badge latest">Latest</span>
-
-<div class="release-date-meta">March 21, 2026</div>
-
-## Feature Section Name
-
-- **Feature Name** — short description of what it does
-- **Another Feature** — description
-
-## Bug Fixes
-
-- **Fix Name** — what was fixed and how
-
-## Improvements
-
-- **Improvement Name** — what changed
-```
-
-4. **Update `docs/releases/index.md`** — add the new entry at the top (newest first) and move the `latest` badge:
-
-```html
-<div class="release-list-item">
-  <a href="/releases/v0.1.0">
-    <h2>v0.1.0</h2>
-  </a>
-  <div class="release-meta">March 21, 2026 <span class="release-badge latest">Latest</span></div>
-  <p class="release-excerpt">Brief summary of major changes in this release.</p>
-</div>
-```
-
-Remove the `<span class="release-badge latest">Latest</span>` from the previous release entry.
-
-5. **Update `package.json` version** to match the new release version.
-
-### Release note conventions
-
-- Group changes by feature area with `##` headings
-- Each item is a bold feature/fix name followed by an em dash and description
-- Keep descriptions concise — one line per item
-- Badge classes: `latest`, `alpha`
-- The sidebar is auto-generated from frontmatter by `getReleaseSidebar()` in `docs/.vitepress/config.ts`
+- No inline styles — use CSS files in `src/renderer/` (each module owns its CSS)
+- Prefer extending the unified overlay over creating new renderer entry points
+- Let Prettier format your files; don't fight the lint hook
 
 ## Default Browser Settings
 


### PR DESCRIPTION
## Summary

Comprehensive update to CLAUDE.md documenting the current state of Nav0 v0.2.9, including major architectural changes, new tooling, and reorganized documentation structure.

## Key Changes

- **Version bump**: Updated from 0.1.1 to 0.2.9
- **Unified overlay system**: Documented the consolidation of modal UI (command-k, options menu, SSL info, alerts, etc.) into a single `UnifiedOverlayManager` with handler pattern, replacing individual overlay managers
- **New managers**: Added documentation for `AppMenuManager`, `SessionManager`, `NotificationManager`, `BrowsingHistoryManager`, `SearchEngine`, and `CLIInstaller`
- **CLI support**: Documented new CLI argument parsing (`-p`, `-u`) and single-instance lock behavior for launching from terminal
- **Session restore**: Added `SessionManager` for persisting/restoring open windows and tabs across app restarts
- **Partition system**: Clarified dual-partition architecture (`persist:browsertabs` for normal, `private` in-memory for private browsing)
- **Linting & formatting**: Expanded tooling section to document ESLint, Stylelint, HTMLHint, Prettier, Husky, and lint-staged integration
- **Build improvements**: Updated Electron Forge configuration details including fuses, ESM workaround, and native module handling
- **Webpack entries**: Consolidated renderer entry points and documented the unified overlay entry pattern
- **Documentation relocation**: Noted that VitePress docs, blog, and release notes now live in separate `nav0-org/website` repo
- **Tech stack updates**: Bumped Electron (35.2.1 → 41.0.0), better-sqlite3 (11.9.1 → 12.9.0), and added new dependencies (pdf-parse, marked, uuid, bluebird)
- **Code conventions**: Updated to reflect unified overlay pattern and preference for extending overlay over creating new renderer entry points
- **Implementation notes**: Added sections on cookie encryption fuse (macOS), private browsing data isolation, dev vs. installed userData, and User-Agent/Client Hints handling

## Notable Details

- Clarified that private browsing uses in-memory SQLite (`:memory:`) and non-persistent session partition to prevent data touching disk
- Documented the display-capture picker as the one exception to the unified overlay pattern due to synchronous loading requirements
- Explained the ESM workaround in Electron 35+ that rewrites `package.json` main field during packaging
- Added guidance on extending the unified overlay system vs. creating new renderer entry points for new UI

https://claude.ai/code/session_01QZV5p1cVsrJCxg3JTFSPKi