### PR TITLE
Skip ad-pattern matching for streaming site sub-resources

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -14,6 +14,7 @@ import {
 } from '../../types/settings-types';
 import { AD_BLOCK_DOMAINS, AD_URL_PATTERNS } from '../ad-blocker/ad-block-lists';
 import { applyClientHints, alignUAWithRealChromeVersion } from '../browser/ua-switcher';
+import { STREAMING_SITES } from '../../constants/app-constants';
 
 export abstract class SettingsEnforcer {
   private static autoDeleteInterval: ReturnType<typeof setInterval> | null = null;
@@ -420,6 +421,24 @@ export abstract class SettingsEnforcer {
         // happen to contain generic words like "popup", "banner", or "ads"
         // (e.g. Bitrix CMS components served under /.../popup/script.js).
         if (topHostname && topHostname === hostname) {
+          callback({});
+          return;
+        }
+
+        // Skip URL-pattern matching for sub-resources of streaming sites.
+        // YouTube's videoplayback range requests to *.googlevideo.com carry
+        // parameters like `&ad_module=` and ad-rule metadata that match the
+        // generic `[?&]ad_` pattern and get canceled, breaking video seeks
+        // (especially in private mode, where the in-memory cache is small
+        // and seeks to unbuffered positions reliably re-fetch). Domain-level
+        // blocking still applies, so video ad networks like imasdk are
+        // still blocked.
+        if (
+          topHostname &&
+          STREAMING_SITES.some(
+            (site) => topHostname === site || topHostname.endsWith('.' + site)
+          )
+        ) {
           callback({});
           return;
         }


### PR DESCRIPTION
## Summary

Fixes video playback issues on streaming sites (particularly YouTube) by exempting their sub-resource requests from URL-pattern-based ad blocking. Domain-level ad blocking still applies, preventing ad networks from loading.

## Problem

YouTube's `videoplayback` range requests to `*.googlevideo.com` include parameters like `&ad_module=` and ad-rule metadata that match the generic `[?&]ad_` URL pattern. When these requests are canceled by the ad blocker, it breaks video seeking—especially in private mode where the in-memory cache is small and seeks to unbuffered positions reliably re-fetch the resource.

## Solution

- Added import of `STREAMING_SITES` constant from `app-constants`
- Added domain-level check in `SettingsEnforcer` before URL-pattern matching
- If the top-level hostname matches a streaming site (exact match or subdomain), skip URL-pattern ad checks and allow the request through
- Domain-level blocking (via `AD_BLOCK_DOMAINS`) still applies, so ad networks like imasdk remain blocked

## Implementation Details

The check is placed early in the request filtering logic to avoid unnecessary pattern matching for known streaming site sub-resources. It uses the existing `topHostname` variable and checks against `STREAMING_SITES` with both exact and subdomain matching.

https://claude.ai/code/session_01PHssKo3ELHWKNBhTwDyaYt