### PR TITLE
Add tab pinning support with session persistence

### DIFF
--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -275,6 +275,7 @@ export interface SessionTabRecord {
   url: string;
   title: string;
   faviconUrl: string | null;
+  isPinned: boolean;
 }
 
 export interface SessionWindowRecord {

--- a/src/main/browser/app-window-manager.ts
+++ b/src/main/browser/app-window-manager.ts
@@ -2,7 +2,6 @@ import {
   ClosedTabRecord,
   ClosedWindowRecord,
   RendererToMainEventsForBrowserIPC,
-  MainToRendererEventsForBrowserIPC,
   DataStoreConstants,
   PartitionNames,
 } from '../../constants/app-constants';
@@ -1227,15 +1226,7 @@ export abstract class AppWindowManager {
           {
             label: isPinned ? 'Unpin Tab' : 'Pin Tab',
             click: () => {
-              if (isPinned) {
-                window
-                  .getBrowserWindowInstance()
-                  ?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_UNPINNED, { id: tabId });
-              } else {
-                window
-                  .getBrowserWindowInstance()
-                  ?.webContents.send(MainToRendererEventsForBrowserIPC.TAB_PINNED, { id: tabId });
-              }
+              window.setTabPinned(tabId, !isPinned);
             },
           },
           { type: 'separator' },

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -561,12 +561,24 @@ export class AppWindow {
     const tab = this.tabs.get(id);
     if (!tab) return;
     tab.setPinned(pinned);
+    this.reorderPinnedTabs();
     this.browserWindowInstance?.webContents.send(
       pinned
         ? MainToRendererEventsForBrowserIPC.TAB_PINNED
         : MainToRendererEventsForBrowserIPC.TAB_UNPINNED,
       { id }
     );
+  }
+
+  // Keep the tab Map ordered with pinned tabs first, preserving each group's
+  // relative order — mirroring how the renderer's tab strip reorders on pin.
+  // This keeps getTabs() (and therefore the saved session order) matching what
+  // the user actually sees.
+  private reorderPinnedTabs(): void {
+    const entries = Array.from(this.tabs.entries());
+    const pinned = entries.filter(([, tab]) => tab.getIsPinned());
+    const unpinned = entries.filter(([, tab]) => !tab.getIsPinned());
+    this.tabs = new Map([...pinned, ...unpinned]);
   }
 
   getBrowserWindowInstance(): BrowserWindow | null {

--- a/src/main/browser/app-window.ts
+++ b/src/main/browser/app-window.ts
@@ -557,6 +557,18 @@ export class AppWindow {
     return this.tabs.get(id) || null;
   }
 
+  setTabPinned(id: string, pinned: boolean): void {
+    const tab = this.tabs.get(id);
+    if (!tab) return;
+    tab.setPinned(pinned);
+    this.browserWindowInstance?.webContents.send(
+      pinned
+        ? MainToRendererEventsForBrowserIPC.TAB_PINNED
+        : MainToRendererEventsForBrowserIPC.TAB_UNPINNED,
+      { id }
+    );
+  }
+
   getBrowserWindowInstance(): BrowserWindow | null {
     return this.browserWindowInstance;
   }

--- a/src/main/browser/session-manager.ts
+++ b/src/main/browser/session-manager.ts
@@ -39,6 +39,7 @@ export abstract class SessionManager {
         url: string;
         title: string;
         faviconUrl: string | null;
+        isPinned: boolean;
         isActive: boolean;
       }[] = [];
       for (const tab of tabs) {
@@ -48,6 +49,7 @@ export abstract class SessionManager {
           url,
           title: tab.getTitle(),
           faviconUrl: tab.getFaviconUrl(),
+          isPinned: tab.getIsPinned(),
           isActive: tab.getId() === activeTabId,
         });
       }
@@ -58,7 +60,12 @@ export abstract class SessionManager {
       if (activeTabIndex === -1) activeTabIndex = 0;
 
       sessionWindows.push({
-        tabs: filteredTabs.map((t) => ({ url: t.url, title: t.title, faviconUrl: t.faviconUrl })),
+        tabs: filteredTabs.map((t) => ({
+          url: t.url,
+          title: t.title,
+          faviconUrl: t.faviconUrl,
+          isPinned: t.isPinned,
+        })),
         activeTabIndex,
       });
     }
@@ -123,8 +130,17 @@ export abstract class SessionManager {
         }
       }
 
-      // Activate the correct tab
+      // Re-apply pinned state. Tabs were created in record order (default tab
+      // for record 0, then the rest), so getTabs() lines up index-for-index
+      // with windowRecord.tabs. The renderer pins and reorders on each event.
       const allTabs = newWindow.getTabs();
+      for (let i = 0; i < windowRecord.tabs.length && i < allTabs.length; i++) {
+        if (windowRecord.tabs[i].isPinned) {
+          newWindow.setTabPinned(allTabs[i].getId(), true);
+        }
+      }
+
+      // Activate the correct tab
       if (windowRecord.activeTabIndex < allTabs.length) {
         newWindow.activateTab(allTabs[windowRecord.activeTabIndex].getId());
       }

--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -99,6 +99,7 @@ export class Tab {
       ) => void)
     | null = null;
   private isSuspended = false;
+  private isPinned = false;
   private lastActivatedAt: Date = new Date();
   private pageStartTime: number | null = null;
   private activeTimeAccumulator = 0;
@@ -1101,6 +1102,14 @@ export class Tab {
 
   getIsSuspended(): boolean {
     return this.isSuspended;
+  }
+
+  getIsPinned(): boolean {
+    return this.isPinned;
+  }
+
+  setPinned(pinned: boolean): void {
+    this.isPinned = pinned;
   }
 
   getLastActivatedAt(): Date {

--- a/src/renderer/browser-layout/browser-manager.ts
+++ b/src/renderer/browser-layout/browser-manager.ts
@@ -213,9 +213,14 @@ export class BrowserTabManager {
       this.tabsContainer.scrollBy({ left: 200, behavior: 'smooth' });
     });
 
-    // Update scroll arrow visibility on scroll and resize
+    // Update scroll arrow visibility on scroll and resize. The resize callback
+    // is deferred to the next frame so toggling the arrows' visibility (which
+    // can itself change layout) doesn't re-enter the observer synchronously and
+    // trip the benign "ResizeObserver loop" warning.
     this.tabsContainer.addEventListener('scroll', () => this.updateTabScrollButtons());
-    new ResizeObserver(() => this.updateTabScrollButtons()).observe(this.tabsContainer);
+    new ResizeObserver(() => {
+      window.requestAnimationFrame(() => this.updateTabScrollButtons());
+    }).observe(this.tabsContainer);
   }
 
   private setupIpcListeners(): void {


### PR DESCRIPTION
## Summary

Implements tab pinning functionality with full session persistence. Users can now pin/unpin tabs via context menu, and pinned tabs are preserved when the browser restarts.

## Key Changes

- **Tab pinning state management** (`src/main/browser/tab.ts`):
  - Added `isPinned` property and getter/setter methods to the `Tab` class

- **AppWindow pinning logic** (`src/main/browser/app-window.ts`):
  - Added `setTabPinned()` method to handle pin/unpin operations and send IPC events to renderer
  - Added `reorderPinnedTabs()` private method to maintain tab order with pinned tabs first, mirroring renderer behavior and ensuring `getTabs()` output matches the UI

- **Session persistence** (`src/main/browser/session-manager.ts`):
  - Extended `SessionTabRecord` interface to include `isPinned` field
  - Updated session save logic to capture pinned state for each tab
  - Updated session restore logic to re-apply pinned state when restoring windows

- **Context menu integration** (`src/main/browser/app-window-manager.ts`):
  - Simplified "Pin Tab" / "Unpin Tab" context menu handler to use the new `setTabPinned()` method instead of directly sending IPC events

- **Constants** (`src/constants/app-constants.ts`):
  - Added `isPinned` field to `SessionTabRecord` interface

- **Renderer optimization** (`src/renderer/browser-layout/browser-manager.ts`):
  - Deferred `ResizeObserver` callback to next animation frame to prevent "ResizeObserver loop" warnings when toggling scroll arrow visibility

## Implementation Details

The pinning system maintains consistency between main and renderer processes:
- When a tab is pinned/unpinned, `reorderPinnedTabs()` reorders the internal tab Map so pinned tabs appear first
- This ensures `getTabs()` returns tabs in the order the user sees them, which is critical for session persistence
- The renderer independently pins/reorders on each `TAB_PINNED`/`TAB_UNPINNED` event, keeping both processes in sync
- On session restore, pinned state is re-applied before tab activation, preserving the user's layout

https://claude.ai/code/session_01TpU69WeVDgnspMuMLmhcuX