### PR TITLE
Prevent duplicate downloads with Chrome-style numeric suffixes

### DIFF
--- a/src/main/browser/tab.ts
+++ b/src/main/browser/tab.ts
@@ -694,18 +694,28 @@ export class Tab {
     if (s.downloadPath && !fs.existsSync(s.downloadPath)) {
       downloadDir = app.getPath('downloads');
     }
-    const downloadPath = path.join(downloadDir, item.getFilename());
-    const downloadId = item.getStartTime().toString() + '_' + item.getFilename();
+    const requestedFileName = item.getFilename();
+    const downloadId = item.getStartTime().toString() + '_' + requestedFileName;
 
     // Prevent duplicate handling when multiple tabs share the same session
     if (Tab.handledDownloads.has(downloadId)) return;
     Tab.handledDownloads.add(downloadId);
 
-    item.setSavePath(downloadPath);
-
     // Check if this is a cross-session resume (triggered by createInterruptedDownload)
     let dbRecordId = DownloadManager.checkResuming(downloadId);
     const isCrossSessionResume = !!dbRecordId;
+
+    // New downloads get a Chrome-style " (n)" suffix when a file of the same
+    // name already exists, so we never clobber it. Resumes must keep their
+    // original path so the partial file on disk is continued, not duplicated.
+    let downloadPath = path.join(downloadDir, requestedFileName);
+    let fileName = requestedFileName;
+    if (!isCrossSessionResume) {
+      downloadPath = Utils.getUniqueFilePath(downloadPath);
+      fileName = path.basename(downloadPath);
+    }
+
+    item.setSavePath(downloadPath);
 
     if (dbRecordId) {
       // Resuming from previous session – update existing record
@@ -715,9 +725,9 @@ export class Tab {
       const record = await DownloadManager.addRecord(
         this.parentAppWindow.id,
         item.getURL(),
-        item.getFilename(),
-        path.extname(item.getFilename()),
-        Utils.getFileType(path.extname(item.getFilename())),
+        fileName,
+        path.extname(fileName),
+        Utils.getFileType(path.extname(fileName)),
         item.getTotalBytes(),
         downloadPath
       );
@@ -735,19 +745,14 @@ export class Tab {
     );
 
     // Track in main process so renderer can query on page load
-    DownloadManager.trackDownloadStarted(
-      downloadId,
-      item.getFilename(),
-      item.getTotalBytes(),
-      dbRecordId
-    );
+    DownloadManager.trackDownloadStarted(downloadId, fileName, item.getTotalBytes(), dbRecordId);
     DownloadManager.storeDownloadItem(downloadId, item);
 
     // Notify renderer (browser chrome + all tabs) that a download has started
     const startedData = {
       downloadId,
       dbRecordId,
-      fileName: item.getFilename(),
+      fileName,
       totalBytes: item.getTotalBytes(),
     };
     this.parentAppWindow
@@ -823,7 +828,7 @@ export class Tab {
 
       const browserWindow = this.parentAppWindow.getBrowserWindowInstance();
       if (!browserWindow?.webContents) return;
-      const completedData = { downloadId, state, fileName: item.getFilename(), dbRecordId };
+      const completedData = { downloadId, state, fileName, dbRecordId };
       browserWindow.webContents.send(
         MainToRendererEventsForBrowserIPC.DOWNLOAD_COMPLETED,
         completedData

--- a/src/main/browser/utils.ts
+++ b/src/main/browser/utils.ts
@@ -1,4 +1,30 @@
+import * as fs from 'fs';
+import path from 'path';
+
 export abstract class Utils {
+  /**
+   * Returns a file path that won't overwrite an existing file. If the desired
+   * path is free it is returned unchanged; otherwise a Chrome-style numeric
+   * suffix is inserted before the extension ("report.pdf" → "report (1).pdf"
+   * → "report (2).pdf").
+   */
+  public static getUniqueFilePath(desiredPath: string): string {
+    if (!fs.existsSync(desiredPath)) return desiredPath;
+
+    const dir = path.dirname(desiredPath);
+    const ext = path.extname(desiredPath);
+    const base = path.basename(desiredPath, ext);
+
+    let counter = 1;
+    let candidate: string;
+    do {
+      candidate = path.join(dir, `${base} (${counter})${ext}`);
+      counter++;
+    } while (fs.existsSync(candidate));
+
+    return candidate;
+  }
+
   public static getFileType(
     fileExtension: string
   ): 'document' | 'image' | 'archive' | 'audio' | 'video' | 'file' | 'executable' | 'other' {


### PR DESCRIPTION
## Summary

This change prevents downloads from overwriting existing files by automatically appending Chrome-style numeric suffixes (e.g., "report (1).pdf") when a file of the same name already exists. Resume downloads preserve their original paths to continue partial files rather than creating duplicates.

## Key Changes

- **New utility method**: Added `Utils.getUniqueFilePath()` that checks for file existence and generates unique paths with `(n)` suffixes before the file extension
- **Download path logic**: Refactored download path handling in `Tab.onWillDownload()` to:
  - Distinguish between new downloads and cross-session resumes
  - Apply unique path generation only to new downloads
  - Keep resumed downloads on their original paths to continue partial files
- **Consistent fileName tracking**: Extracted `fileName` variable to track the actual saved filename (which may differ from the requested filename due to uniqueness handling), ensuring all download notifications and database records use the correct filename

## Implementation Details

- The unique path generation follows Chrome's convention: `filename (1).ext`, `filename (2).ext`, etc.
- Cross-session resume detection (via `DownloadManager.checkResuming()`) gates the unique path logic—resumed downloads skip this step to avoid duplicating partial files
- All download tracking, database records, and renderer notifications now use the actual `fileName` rather than `item.getFilename()`, ensuring consistency across the download lifecycle

https://claude.ai/code/session_01XFaYA7636j58Q3MpykyqmP