### PR TITLE
Refactor filter list UI layout and add permission origin groups

### DIFF
--- a/src/renderer/pages/browser-settings/index.css
+++ b/src/renderer/pages/browser-settings/index.css
@@ -399,6 +399,13 @@
   box-shadow: none;
 }
 
+/* A description that follows a .sub-label inside an unpadded group body
+   needs the same 16px inset so it lines up with the label and list rows. */
+#adblocker-details > .setting-description {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
 .sub-label {
   padding: 12px 16px 6px;
   font-size: 11px;
@@ -756,6 +763,12 @@
   gap: 8px;
   align-items: center;
   padding: 12px 16px;
+}
+
+/* The custom search engine form has a third field (name), so it needs an
+   extra column or the URL input collapses and the button wraps to a new row. */
+#add-engine-form {
+  grid-template-columns: auto 1fr auto;
 }
 
 /* ====== SUB-SETTINGS (nested panels) ==================== */

--- a/src/renderer/pages/browser-settings/index.css
+++ b/src/renderer/pages/browser-settings/index.css
@@ -289,7 +289,9 @@
   padding: 12px 16px;
   border-bottom: 1px solid var(--border-1);
   background: var(--bg-0);
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .setting-group-header > div:first-child {
@@ -755,6 +757,13 @@
 
 .list-item-content {
   min-width: 0;
+}
+
+.list-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .add-item-form {

--- a/src/renderer/pages/browser-settings/index.css
+++ b/src/renderer/pages/browser-settings/index.css
@@ -772,6 +772,25 @@
   border-bottom: 0;
 }
 
+/* List-style sub-settings (allow / block / exception lists) stack their
+   label, description, list and add-form vertically instead of using the
+   default label|control grid, which would split them into a 2x2 layout. */
+#cookie-exceptions-container,
+#popup-allowed-container,
+#popup-blocked-container {
+  display: block;
+}
+
+#cookie-exceptions-container .list-item,
+#popup-allowed-container .list-item,
+#popup-blocked-container .list-item,
+#cookie-exceptions-container .add-item-form,
+#popup-allowed-container .add-item-form,
+#popup-blocked-container .add-item-form {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 .sub-setting-panel {
   background: var(--bg-1);
   border-top: 1px solid var(--border-1);
@@ -1161,6 +1180,59 @@ kbd,
 
 .permission-entry-decision .form-select-sm {
   min-width: 120px;
+}
+
+/* Origin group: a card grouping all the permissions for one site */
+.permission-origin-group {
+  margin-bottom: 16px;
+  border: 1px solid var(--border-1);
+  border-radius: var(--r-sm);
+  background: var(--bg-0);
+  overflow: hidden;
+}
+
+.permission-origin-group:last-child {
+  margin-bottom: 0;
+}
+
+.permission-origin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border-1);
+}
+
+.permission-origin-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.permission-origin-favicon {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  object-fit: contain;
+  color: var(--n0-text-2);
+}
+
+.permission-origin-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--n0-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.permission-origin-actions {
+  flex-shrink: 0;
 }
 
 /* ====== CHECKBOX OPTIONS (dialogs etc.) ================ */

--- a/src/renderer/pages/browser-settings/index.ts
+++ b/src/renderer/pages/browser-settings/index.ts
@@ -560,16 +560,16 @@ function renderFilterLists() {
     item.className = 'list-item';
     item.innerHTML = `
       <div class="list-item-content">
-        <label class="toggle" style="margin-right: 8px;">
+        <div class="list-item-text" style="font-family: var(--n0-sans); font-weight: 500;">${list.name}</div>
+        <div class="list-item-description" style="font-family: var(--n0-sans);">${list.description}</div>
+      </div>
+      <div class="list-item-actions">
+        <label class="toggle">
           <input type="checkbox" ${list.enabled ? 'checked' : ''} data-idx="${idx}">
           <span class="toggle-slider"></span>
         </label>
-        <div>
-          <div class="list-item-text" style="font-family: var(--n0-sans); font-weight: 500;">${list.name}</div>
-          <div class="list-item-description" style="font-family: var(--n0-sans);">${list.description}</div>
-        </div>
+        ${!list.isBuiltIn ? `<button class="list-item-btn" data-idx="${idx}" title="Remove"><i data-lucide="x" width="14" height="14"></i></button>` : ''}
       </div>
-      ${!list.isBuiltIn ? `<div class="list-item-actions"><button class="list-item-btn" data-idx="${idx}" title="Remove"><i data-lucide="x" width="14" height="14"></i></button></div>` : ''}
     `;
 
     const checkbox = item.querySelector('input[type="checkbox"]') as HTMLInputElement;


### PR DESCRIPTION
## Summary

This PR improves the layout and styling of the browser settings page, focusing on two main areas:

1. **Filter list item restructuring**: Reorganizes the filter list items to use a flexbox-based layout with separated content and actions sections, improving visual hierarchy and alignment.

2. **Permission origin groups**: Adds new CSS classes and layout structure for displaying site permissions grouped by origin, with headers showing favicon, site name, and action buttons.

3. **Layout refinements**: Updates various settings components (setting group headers, list items, sub-settings) to use flexbox for better alignment and spacing consistency.

## Key Changes

- **Filter list items** (`renderFilterLists`):
  - Restructured HTML to separate content (name + description) from actions (toggle + remove button)
  - Moved toggle checkbox into a new `.list-item-actions` container
  - Improved semantic structure with dedicated `.list-item-text` and `.list-item-description` divs

- **CSS layout improvements**:
  - Changed `.setting-group-header` from `display: block` to `display: flex` with centered alignment and 16px gap
  - Added `.list-item-actions` flexbox container for action buttons (8px gap, no shrink)
  - Added `.permission-origin-group` card styling with border, border-radius, and overflow handling
  - Added `.permission-origin-header` with flex layout for origin info and actions
  - Added `.permission-origin-title`, `.permission-origin-favicon`, `.permission-origin-name`, and `.permission-origin-actions` classes for origin group structure

- **Sub-settings refinements**:
  - Added explicit `display: block` for list-style sub-settings (cookie exceptions, popup allow/block lists)
  - Removed horizontal padding from list items and forms within these containers for proper alignment
  - Added special grid layout for `#add-engine-form` with three columns to accommodate the name field

- **Description padding**:
  - Added left/right padding to `#adblocker-details > .setting-description` to align with other content

## Implementation Details

The changes maintain backward compatibility while improving the visual consistency of the settings UI. The new permission origin group classes follow the existing naming conventions and use CSS custom properties for theming (colors, spacing, border radius). The filter list restructuring preserves all functionality while improving the DOM structure for better layout control.

https://claude.ai/code/session_01J2TeeqRH4be5C7bBocURPN