### PR TITLE
Refactor first-party request detection in ad blocker

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -407,11 +407,22 @@ export abstract class SettingsEnforcer {
           }
         }
 
-        // Check if hostname matches any blocked domain
-        for (const domain of SettingsEnforcer.adBlockDomains) {
-          if (hostname === domain || hostname.endsWith('.' + domain)) {
-            callback({ cancel: true });
-            return;
+        // Domain blocking targets third-party trackers/ads embedded in other
+        // sites — it must never cancel a top-level navigation or a first-party
+        // request. Some listed domains (e.g. webengage.com, a marketing SaaS)
+        // also serve their own website; blocking the mainFrame request makes
+        // the site unreachable, with no privacy benefit since the user
+        // deliberately went there. Third-party requests stay blocked.
+        const requestDomain = SettingsEnforcer.getRegistrableDomain(hostname);
+        const topDomain = topHostname ? SettingsEnforcer.getRegistrableDomain(topHostname) : '';
+        const isFirstParty = topDomain !== '' && requestDomain === topDomain;
+        if (details.resourceType !== 'mainFrame' && !isFirstParty) {
+          // Check if hostname matches any blocked domain
+          for (const domain of SettingsEnforcer.adBlockDomains) {
+            if (hostname === domain || hostname.endsWith('.' + domain)) {
+              callback({ cancel: true });
+              return;
+            }
           }
         }
 

--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -407,33 +407,26 @@ export abstract class SettingsEnforcer {
           }
         }
 
-        // Domain blocking targets third-party trackers/ads embedded in other
-        // sites — it must never cancel a top-level navigation or a first-party
-        // request. Some listed domains (e.g. webengage.com, a marketing SaaS)
-        // also serve their own website; blocking the mainFrame request makes
-        // the site unreachable, with no privacy benefit since the user
-        // deliberately went there. Third-party requests stay blocked.
+        // Neither blocklist below may cancel a top-level navigation or a
+        // first-party request — both target third-party trackers/ads embedded
+        // in other sites, so applying them to a page the user opened directly
+        // (or its own assets) breaks the site with no privacy benefit. Some
+        // listed domains (e.g. webengage.com) also serve their own website.
+        // Registrable-domain match keeps a site's own subdomains first-party.
         const requestDomain = SettingsEnforcer.getRegistrableDomain(hostname);
         const topDomain = topHostname ? SettingsEnforcer.getRegistrableDomain(topHostname) : '';
         const isFirstParty = topDomain !== '' && requestDomain === topDomain;
-        if (details.resourceType !== 'mainFrame' && !isFirstParty) {
-          // Check if hostname matches any blocked domain
-          for (const domain of SettingsEnforcer.adBlockDomains) {
-            if (hostname === domain || hostname.endsWith('.' + domain)) {
-              callback({ cancel: true });
-              return;
-            }
-          }
-        }
-
-        // Skip generic URL pattern matching for first-party (same-host)
-        // requests. The patterns are designed to catch third-party ad URLs
-        // and produce false positives on legitimate site assets whose paths
-        // happen to contain generic words like "popup", "banner", or "ads"
-        // (e.g. Bitrix CMS components served under /.../popup/script.js).
-        if (topHostname && topHostname === hostname) {
+        if (details.resourceType === 'mainFrame' || isFirstParty) {
           callback({});
           return;
+        }
+
+        // Check if hostname matches any blocked domain
+        for (const domain of SettingsEnforcer.adBlockDomains) {
+          if (hostname === domain || hostname.endsWith('.' + domain)) {
+            callback({ cancel: true });
+            return;
+          }
         }
 
         // Skip URL-pattern matching for sub-resources of streaming sites.
@@ -458,10 +451,6 @@ export abstract class SettingsEnforcer {
         const urlString = details.url;
         for (const pattern of AD_URL_PATTERNS) {
           if (pattern.test(urlString)) {
-            // Don't block navigations to avoid breaking page loads
-            if (details.resourceType === 'mainFrame') {
-              break;
-            }
             callback({ cancel: true });
             return;
           }


### PR DESCRIPTION
## Summary

Consolidates and improves first-party request detection in the ad blocker to prevent blocking legitimate site assets and top-level navigations. The logic now uses registrable domain matching consistently across all blocklist checks.

## Key Changes

- **Unified first-party detection**: Introduced a single, early check using `getRegistrableDomain()` to identify first-party requests (same registrable domain as top-level page) and main-frame navigations
- **Moved check earlier**: The first-party check now runs before domain blocklist matching, preventing unnecessary iterations through blocked domains for requests that should never be blocked
- **Removed redundant checks**: Eliminated the separate first-party check that only compared hostnames directly (`topHostname === hostname`), which was less robust than registrable domain matching
- **Simplified URL pattern matching**: Removed the inline `mainFrame` check from URL pattern matching since main-frame navigations are now caught by the early return
- **Improved comments**: Added detailed explanation of why first-party and main-frame requests must never be blocked (prevents breaking legitimate site functionality)

## Implementation Details

The refactored logic:
1. Extracts the registrable domain from both the request hostname and top-level hostname
2. Determines if the request is first-party by comparing registrable domains
3. Returns early (no blocking) if the request is a main-frame navigation OR a first-party request
4. Proceeds with blocklist checks only for third-party requests

This approach is more robust than simple hostname comparison because it correctly handles subdomains (e.g., `cdn.example.com` and `example.com` are first-party to each other) while still blocking third-party trackers embedded in those sites.

https://claude.ai/code/session_01ARUMdiQicf8MUDGxPSsNa7