### PR TITLE
Skip reinstall if current version already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,54 @@ case "$ARCH" in
     ;;
 esac
 
+# Read the installed Nav0 version from the bundle's Info.plist, if present.
+get_installed_version() {
+  local path
+  for path in "/Applications/$APP_NAME.app" "$HOME/Desktop/$APP_NAME.app"; do
+    if [ -d "$path" ]; then
+      local v
+      v=$(defaults read "$path/Contents/Info" CFBundleShortVersionString 2>/dev/null || true)
+      if [ -n "$v" ]; then
+        echo "$v"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+# Returns 0 if $1 >= $2 using semver-style ordering via sort -V.
+version_ge() {
+  [ "$1" = "$2" ] && return 0
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]
+}
+
+# Get latest release tag
+echo "Fetching latest release..."
+TAG=$(curl -sfL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+
+if [ -z "$TAG" ]; then
+  echo "Error: Could not determine latest release"
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+DMG_NAME="${APP_NAME}-${VERSION}-${ARCH_SUFFIX}.dmg"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$DMG_NAME"
+
+# Skip the install if the user already has this version (or newer).
+# Bail before the running-app prompt so we don't kill Nav0 just to no-op.
+if [ "${NAV0_FORCE_REINSTALL:-}" != "1" ]; then
+  if INSTALLED_VERSION=$(get_installed_version); then
+    if version_ge "$INSTALLED_VERSION" "$VERSION"; then
+      echo "Nav0 $INSTALLED_VERSION is already installed (latest: $VERSION)."
+      echo "Set NAV0_FORCE_REINSTALL=1 to reinstall anyway."
+      exit 0
+    fi
+    echo "Updating Nav0 from $INSTALLED_VERSION to $VERSION..."
+  fi
+fi
+
 # Check if Nav0 is currently running; offer to quit and continue.
 if pgrep -x "$APP_NAME" >/dev/null 2>&1 \
    || pgrep -f "/${APP_NAME}.app/Contents/MacOS/${APP_NAME}" >/dev/null 2>&1; then
@@ -72,19 +120,6 @@ if pgrep -x "$APP_NAME" >/dev/null 2>&1 \
   fi
   echo "Nav0 stopped."
 fi
-
-# Get latest release tag
-echo "Fetching latest release..."
-TAG=$(curl -sfL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | head -1 | cut -d'"' -f4)
-
-if [ -z "$TAG" ]; then
-  echo "Error: Could not determine latest release"
-  exit 1
-fi
-
-VERSION="${TAG#v}"
-DMG_NAME="${APP_NAME}-${VERSION}-${ARCH_SUFFIX}.dmg"
-DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$DMG_NAME"
 
 TMPDIR_INSTALL=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_INSTALL"' EXIT


### PR DESCRIPTION
## Summary

Refactors the install script to check the installed Nav0 version before prompting the user to quit the running application. If the installed version is already at or newer than the latest release, the script exits early without interrupting the user's session.

## Key Changes

- **Added `get_installed_version()` function**: Reads the installed Nav0 version from `Info.plist` by checking `/Applications/$APP_NAME.app` and `$HOME/Desktop/$APP_NAME.app`
- **Added `version_ge()` function**: Implements semantic version comparison using `sort -V` to determine if one version is greater than or equal to another
- **Moved release fetching earlier**: Moved the GitHub API call to fetch the latest release tag before the running-app check, enabling version comparison
- **Added early exit logic**: If the installed version is already at or newer than the latest release, the script exits with status 0 without prompting to quit Nav0
- **Added `NAV0_FORCE_REINSTALL` override**: Users can set `NAV0_FORCE_REINSTALL=1` to force reinstallation even if the current version matches
- **Improved user messaging**: Added informative messages about version comparisons and update status

## Implementation Details

- The version check happens before the running-app prompt, avoiding unnecessary interruption of the user's workflow
- Version comparison uses `sort -V` for proper semantic versioning (e.g., 0.2.9 > 0.2.10 is correctly handled)
- The `get_installed_version()` function gracefully handles missing installations by returning a non-zero exit code
- Error handling preserved for cases where the latest release cannot be determined

https://claude.ai/code/session_012mc4hKQdMFxi36MvUdwSXF