### PR TITLE
Exempt main frame navigation from third-party cookie filtering

### DIFF
--- a/src/main/settings/settings-enforcer.ts
+++ b/src/main/settings/settings-enforcer.ts
@@ -215,6 +215,20 @@ export abstract class SettingsEnforcer {
           return;
         }
 
+        // A top-level navigation is always first-party to itself: the document
+        // being loaded *is* the site, so its own Set-Cookie is never a
+        // third-party cookie — regardless of which site referred us here. This
+        // matters for sign-in redirect chains that hop across origins (e.g. a
+        // Google/SSO step lands back on github.com with an accounts.google.com
+        // referrer). Without this exemption we'd strip the destination's own
+        // session cookie, and the follow-up page (e.g. GitHub's
+        // /sessions/two-factor/app) 404s because the pending session is gone.
+        // Only sub-resources / sub-frames can legitimately be third-party.
+        if (details.resourceType === 'mainFrame') {
+          callback({ responseHeaders: details.responseHeaders });
+          return;
+        }
+
         // Determine if this is a third-party request
         const requestUrl = new URL(details.url);
         const frameUrl = details.frame?.url || details.referrer || '';


### PR DESCRIPTION
## Summary

Fixes an issue where top-level navigation (main frame) requests were incorrectly having their Set-Cookie headers filtered as if they were third-party cookies. This caused session cookies to be stripped during sign-in redirect chains that hop across origins, breaking authentication flows.

## Changes

- Added an exemption in `SettingsEnforcer` to skip third-party cookie filtering for `mainFrame` resource types
- A top-level navigation is always first-party to itself — the document being loaded *is* the site, so its own Set-Cookie headers should never be filtered regardless of the referrer
- This preserves the intended behavior for sub-resources and sub-frames, which can legitimately be third-party

## Implementation Details

The fix is placed early in the cookie filtering logic before the third-party determination check. This ensures that main frame navigations (e.g., following a redirect from `accounts.google.com` back to `github.com`) retain their session cookies, allowing subsequent pages like `/sessions/two-factor/app` to load correctly instead of 404ing due to a missing pending session.

This is particularly important for sign-in flows that use redirect chains across multiple origins, which are common in OAuth/SSO implementations.

https://claude.ai/code/session_01BnBWtn5MyrwKatMjzciqcZ